### PR TITLE
feat: connect to Wi-Fi and sync UTC time via NTP

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -1,0 +1,4 @@
+#pragma once
+
+#define WIFI_SSID     "your-ssid"
+#define WIFI_PASSWORD "your-password"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <OneWire.h>
 #include <DallasTemperature.h>
 #include "pins.h"
+#include "wifi_ntp.h"
 
 OneWire oneWire(ONE_WIRE_PIN);
 DallasTemperature sensors(&oneWire);
@@ -19,6 +20,9 @@ float readTemperatureCelsius() {
 void setup() {
   Serial.begin(115200);
   Serial.println("FishHub firmware booting...");
+
+  connectWifi();
+  waitForNtp();
 
   sensors.begin();
   int deviceCount = sensors.getDeviceCount();

--- a/src/wifi_ntp.cpp
+++ b/src/wifi_ntp.cpp
@@ -1,0 +1,52 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <time.h>
+#include "wifi_ntp.h"
+#include "config.h"
+
+static const int WIFI_TIMEOUT_MS  = 10000;
+static const int WIFI_MAX_RETRIES = 3;
+static const int NTP_TIMEOUT_MS   = 10000;
+
+void connectWifi() {
+  for (int attempt = 1; attempt <= WIFI_MAX_RETRIES; attempt++) {
+    Serial.printf("Wi-Fi connecting (attempt %d/%d)...\n", attempt, WIFI_MAX_RETRIES);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - start < WIFI_TIMEOUT_MS) {
+      delay(200);
+    }
+
+    if (WiFi.status() == WL_CONNECTED) {
+      Serial.printf("Wi-Fi connected — IP: %s\n", WiFi.localIP().toString().c_str());
+      return;
+    }
+
+    WiFi.disconnect(true);
+    Serial.println("Wi-Fi attempt timed out");
+  }
+
+  Serial.println("Wi-Fi connection failed after 3 attempts — halting");
+  while (true) delay(1000);
+}
+
+void waitForNtp() {
+  configTime(0, 0, "pool.ntp.org");
+  Serial.println("Waiting for NTP sync...");
+
+  struct tm timeinfo;
+  unsigned long start = millis();
+  while (!getLocalTime(&timeinfo) && millis() - start < NTP_TIMEOUT_MS) {
+    delay(200);
+  }
+
+  if (!getLocalTime(&timeinfo)) {
+    Serial.println("NTP sync failed — halting");
+    while (true) delay(1000);
+  }
+
+  char buf[32];
+  strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &timeinfo);
+  Serial.printf("NTP synced: %s\n", buf);
+}

--- a/src/wifi_ntp.h
+++ b/src/wifi_ntp.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void connectWifi();
+void waitForNtp();


### PR DESCRIPTION
Closes #3.

## What changed

- `include/config.h.example` — committed template for Wi-Fi credentials (actual `config.h` is gitignored)
- `src/wifi_ntp.h` / `src/wifi_ntp.cpp` — `connectWifi()` retries up to 3 times (10s each) before halting; `waitForNtp()` blocks up to 10s for NTP sync
- `src/main.cpp` — calls `connectWifi()` and `waitForNtp()` in `setup()` before sensor init

## Testing

`pio run` compiles successfully. Flash, fill in `include/config.h` with real credentials, and open the serial monitor to verify Wi-Fi connection and NTP sync output.