### PR TITLE
feat: POST SenML payload to backend with Bearer token auth

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -2,3 +2,6 @@
 
 #define WIFI_SSID     "your-ssid"
 #define WIFI_PASSWORD "your-password"
+
+#define SERVER_URL   "http://192.168.x.x:8080/readings"
+#define DEVICE_TOKEN "your-32-byte-hex-token"

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,0 +1,40 @@
+#include "http_client.h"
+#include <HTTPClient.h>
+#include "config.h"
+
+static bool doPost(const String& payload, int& statusCode) {
+  HTTPClient http;
+  http.begin(SERVER_URL);
+  http.addHeader("Content-Type", "application/json");
+  http.addHeader("Authorization", "Bearer " DEVICE_TOKEN);
+
+  unsigned long start = millis();
+  statusCode = http.POST(payload);
+  unsigned long elapsed = millis() - start;
+
+  http.end();
+
+  if (statusCode > 0) {
+    Serial.printf("POST %d in %lums\n", statusCode, elapsed);
+  } else {
+    Serial.printf("POST error: %s\n", HTTPClient::errorToString(statusCode).c_str());
+  }
+
+  return statusCode >= 200 && statusCode < 300;
+}
+
+bool postReading(const String& payload) {
+  int statusCode;
+
+  if (doPost(payload, statusCode)) {
+    return true;
+  }
+
+  if (statusCode >= 500 || statusCode < 0) {
+    Serial.println("Retrying POST...");
+    delay(1000);
+    return doPost(payload, statusCode);
+  }
+
+  return false;
+}

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Arduino.h>
+
+bool postReading(const String& payload);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "pins.h"
 #include "wifi_ntp.h"
 #include "senml.h"
+#include "http_client.h"
 
 OneWire oneWire(ONE_WIRE_PIN);
 DallasTemperature sensors(&oneWire);
@@ -39,7 +40,7 @@ void loop() {
   if (!isnan(temp)) {
     Serial.printf("Temp: %.2f °C\n", temp);
     String payload = buildSenMLPayload(temp, time(nullptr));
-    Serial.printf("SenML: %s\n", payload.c_str());
+    postReading(payload);
   }
   delay(5000);
 }


### PR DESCRIPTION
Closes #5.

## What changed

- `include/config.h.example` — added `SERVER_URL` and `DEVICE_TOKEN` placeholders
- `src/http_client.h` / `src/http_client.cpp` — `postReading(payload)` POSTs to `SERVER_URL` with `Authorization: Bearer` header; retries once on 5xx or connection error; logs response code and round-trip time
- `src/main.cpp` — calls `postReading()` in `loop()` after building the SenML payload

## Testing

`pio run` compiles successfully. End-to-end testing requires the backend running locally — fill in `SERVER_URL` and `DEVICE_TOKEN` in `include/config.h` before flashing.