### PR TITLE
docs: create docs/ folder with firmware documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,68 @@
+# Architecture
+
+## Source layout
+
+```
+fishhub-firmware/
+├── platformio.ini          # build environments (nodemcu-32s, native)
+├── include/
+│   ├── pins.h              # GPIO pin definitions
+│   ├── config.h            # credentials (gitignored)
+│   └── config.h.example    # template for config.h
+├── src/
+│   ├── main.cpp            # entry point: setup() + loop()
+│   ├── wifi_ntp.h/.cpp     # Wi-Fi connection + NTP time sync
+│   ├── senml.h/.cpp        # SenML JSON payload builder
+│   └── http_client.h/.cpp  # HTTP POST with retry logic
+├── lib/                    # (reserved for local libraries)
+└── test/
+    └── test_senml/
+        └── test_main.cpp   # native unit tests for SenML builder
+```
+
+## Module responsibilities
+
+### `main.cpp`
+Entry point. `setup()` connects Wi-Fi, syncs NTP, and initialises the DS18B20 sensor. `loop()` reads temperature, builds the SenML payload, and POSTs it — then calls `delay(5000)`.
+
+### `wifi_ntp.h` / `wifi_ntp.cpp`
+- `connectWifi()` — attempts up to 3 connections (10 s timeout each). Halts on total failure.
+- `waitForNtp()` — calls `configTime(0, 0, "pool.ntp.org")` and blocks until `getLocalTime()` succeeds (10 s timeout). Halts on failure.
+
+### `senml.h` / `senml.cpp`
+- `buildSenMLPayload(float tempCelsius, time_t timestamp)` — serialises a single SenML record with ArduinoJson. Returns an Arduino `String`. See [wire-format.md](wire-format.md) for the schema.
+
+### `http_client.h` / `http_client.cpp`
+- `postReading(const String& payload)` — POSTs the payload to `SERVER_URL` with `Authorization: Bearer <DEVICE_TOKEN>`. On a 5xx or network error, retries once after 1 s.
+
+### `include/pins.h`
+Defines `ONE_WIRE_PIN 4` — the GPIO pin the DS18B20 data line is connected to.
+
+## Boot flow
+
+```
+setup()
+  ├── Serial.begin(115200)
+  ├── connectWifi()        — blocks until connected or halts
+  ├── waitForNtp()         — blocks until UTC time is synced or halts
+  └── sensors.begin()      — initialises DS18B20 on OneWire bus
+
+loop()  (runs repeatedly, no deep sleep in current implementation)
+  ├── sensors.requestTemperatures()
+  ├── sensors.getTempCByIndex(0) → float temp
+  ├── [skip if NaN — sensor disconnected]
+  ├── buildSenMLPayload(temp, time(nullptr)) → String payload
+  ├── postReading(payload)
+  └── delay(5000)          — 5-second pause before next reading
+```
+
+> **Note:** Deep sleep is not yet implemented — the device stays awake and loops every 5 seconds (see GitHub issue #6).
+
+## PlatformIO environments
+
+| Environment | Target | Purpose |
+|---|---|---|
+| `nodemcu-32s` | ESP32 hardware | Default build + flash |
+| `native` | Host machine | Unit tests (`pio test -e native`) |
+
+The `native` environment excludes all `src/` files (`build_src_filter = -<*>`) and only compiles `test/` code, avoiding Arduino/ESP32 SDK dependencies.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,55 @@
+# Configuration
+
+## `config.h`
+
+`include/config.h` is **gitignored** and must be created locally before building. Use the provided template:
+
+```bash
+cp include/config.h.example include/config.h
+```
+
+Then fill in the four required defines:
+
+```cpp
+#define WIFI_SSID     "your-ssid"
+#define WIFI_PASSWORD "your-password"
+
+#define SERVER_URL   "http://192.168.x.x:8080/readings"
+#define DEVICE_TOKEN "your-64-char-hex-token"
+```
+
+| Define | Description |
+|---|---|
+| `WIFI_SSID` | SSID of the Wi-Fi network the ESP32 will join |
+| `WIFI_PASSWORD` | Wi-Fi password |
+| `SERVER_URL` | Full URL of the `POST /readings` endpoint on the FishHub backend. Use the local IP of the machine running the server — `localhost` won't resolve on device. |
+| `DEVICE_TOKEN` | 64-char hex Bearer token issued by `POST /tokens` on the server |
+
+## Provisioning a new device
+
+1. Start the FishHub backend (`make dev` in `fishhub-server/`).
+2. Issue a token:
+   ```bash
+   curl -s -X POST http://localhost:8080/tokens | jq
+   ```
+3. Copy the `"token"` value from the response into `config.h` as `DEVICE_TOKEN`.
+4. Find your machine's local IP (the Makefile prints it on `make dev`):
+   ```bash
+   ipconfig getifaddr en0   # Wi-Fi
+   ipconfig getifaddr en1   # Ethernet
+   ```
+5. Set `SERVER_URL` to `http://<your-ip>:8080/readings`.
+6. Build and flash:
+   ```bash
+   pio run --target upload
+   ```
+
+## `include/pins.h`
+
+Pin assignments are in `include/pins.h`:
+
+```cpp
+#define ONE_WIRE_PIN 4
+```
+
+GPIO 4 is the data line for the DS18B20 OneWire bus. Change this if you wire the sensor to a different pin.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,91 @@
+# Development Guide
+
+## Prerequisites
+
+- [PlatformIO Core](https://docs.platformio.org/en/latest/core/installation/) (CLI) or PlatformIO IDE extension
+- USB cable to connect the NodeMCU-32S
+- `include/config.h` filled in (see [configuration.md](configuration.md))
+
+## Common commands
+
+```bash
+# Build for ESP32 (default environment)
+pio run
+
+# Build + flash to connected device
+pio run --target upload
+
+# Open Serial monitor (115200 baud)
+pio device monitor
+
+# Build and flash, then open monitor
+pio run --target upload && pio device monitor
+
+# Run native unit tests (host machine, no device needed)
+pio test -e native
+```
+
+## Serial output
+
+After flashing, the Serial monitor shows the boot sequence and each reading cycle:
+
+```
+FishHub firmware booting...
+Wi-Fi connecting (attempt 1/3)...
+Wi-Fi connected — IP: 192.168.1.42
+Waiting for NTP sync...
+NTP synced: 2024-04-13 12:00:00 UTC
+1 DS18B20 sensor(s) found
+Temp: 23.40 °C
+POST 201 in 83ms
+Temp: 23.41 °C
+POST 201 in 76ms
+```
+
+A `POST error:` line means a network failure. A `POST 401` means the token in `config.h` is invalid. A `POST 400` means the server rejected the payload.
+
+## Unit tests
+
+Tests live in `test/test_senml/test_main.cpp` and run on the host machine using the `native` PlatformIO environment. They test `buildSenMLPayload` directly by re-implementing the logic without Arduino SDK dependencies.
+
+```bash
+pio test -e native
+```
+
+The test suite covers: happy path, negative temperature, and zero temperature.
+
+Hardware-coupled code (`wifi_ntp`, `http_client`) is verified via Serial output after flashing — there are no automated tests for those modules.
+
+## Adding a library dependency
+
+Add it to `platformio.ini` under `[env:nodemcu-32s]` (and `[env:native]` if the test suite needs it):
+
+```ini
+lib_deps =
+  author/Library @ ^version
+```
+
+PlatformIO downloads and pins dependencies automatically on next build.
+
+## `platformio.ini` environments
+
+```ini
+[platformio]
+default_envs = nodemcu-32s
+
+[env:nodemcu-32s]
+platform      = espressif32
+board         = nodemcu-32s
+framework     = arduino
+monitor_speed = 115200
+lib_deps =
+  paulstoffregen/OneWire @ ^2.3.8
+  milesburton/DallasTemperature @ ^3.11.0
+  bblanchon/ArduinoJson @ ^7.3.1
+
+[env:native]
+platform = native
+lib_deps =
+  bblanchon/ArduinoJson @ ^7.3.1
+build_src_filter = -<*>   # exclude src/ — tests import their own stubs
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# fishhub-firmware — Documentation Index
+
+ESP32 Arduino firmware for FishHub aquarium monitoring. On each boot cycle it reads water temperature from a DS18B20 probe, formats a SenML JSON payload, POSTs it to the FishHub backend, and loops.
+
+## Contents
+
+| Document | What it covers |
+|---|---|
+| [architecture.md](architecture.md) | Source layout, module responsibilities, boot flow |
+| [configuration.md](configuration.md) | `config.h` required defines, device provisioning |
+| [wire-format.md](wire-format.md) | SenML JSON structure, example payload, field semantics |
+| [development.md](development.md) | Build, flash, Serial monitor, unit tests |
+
+## Quick start
+
+```bash
+# 1. Copy and fill in credentials
+cp include/config.h.example include/config.h
+# edit config.h with your Wi-Fi, SERVER_URL, and DEVICE_TOKEN
+
+# 2. Build
+pio run
+
+# 3. Flash
+pio run --target upload
+
+# 4. Monitor Serial output
+pio device monitor
+```
+
+## Tech stack
+
+| Concern | Choice |
+|---|---|
+| Build system | PlatformIO |
+| Board | NodeMCU-32S (ESP32) |
+| Framework | Arduino |
+| Temperature sensor | DS18B20 via OneWire / DallasTemperature |
+| JSON serialization | ArduinoJson v7 |
+| HTTP client | ESP32 built-in HTTPClient |
+| Wire format | SenML JSON (RFC 8428) |
+| Auth | Bearer token (hardcoded in `config.h`) |

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -1,0 +1,49 @@
+# Wire Format
+
+Sensor readings are sent as **SenML JSON** (RFC 8428).
+
+## Payload structure
+
+```json
+[{
+  "bn": "fishhub/device/",
+  "bt": 1713000000,
+  "e": [{"n": "temperature", "u": "Cel", "v": 23.4}]
+}]
+```
+
+The payload is a JSON array containing a single SenML record (object).
+
+| Field | Type | Description |
+|---|---|---|
+| `bn` | string | Base name — device namespace, always `"fishhub/device/"` |
+| `bt` | int64 | Base time — Unix UTC timestamp of the reading (seconds since epoch) |
+| `e` | array | Array of SenML entries (measurements) |
+| `e[0].n` | string | Entry name — always `"temperature"` |
+| `e[0].u` | string | Unit — always `"Cel"` (Celsius, per RFC 8428 unit registry) |
+| `e[0].v` | float | Temperature value in Celsius |
+
+## How it's built
+
+`buildSenMLPayload(float tempCelsius, time_t timestamp)` in `src/senml.cpp` uses ArduinoJson to construct the payload:
+
+```cpp
+JsonDocument doc;
+JsonObject record = doc.add<JsonObject>();
+record["bn"] = "fishhub/device/";
+record["bt"] = (long)timestamp;
+JsonObject entry = record["e"].add<JsonObject>();
+entry["n"] = "temperature";
+entry["u"] = "Cel";
+entry["v"] = tempCelsius;
+```
+
+`timestamp` comes from `time(nullptr)` — the current Unix time as synced via NTP on boot.
+
+## Server expectations
+
+The server's `POST /readings` endpoint parses this format. It requires:
+- `bt` to be present and non-zero
+- At least one entry in `e` with `n == "temperature"`
+
+A `400` response means the payload was malformed. A `401` means the Bearer token in `Authorization` is missing or invalid.


### PR DESCRIPTION
Adds a `docs/` folder with five files covering the complete firmware:

- `index.md` — overview, quick-start, tech stack
- `architecture.md` — source layout, module responsibilities, boot flow, PlatformIO environments
- `configuration.md` — `config.h` defines, device provisioning steps
- `wire-format.md` — SenML JSON schema, field semantics, server expectations
- `development.md` — PlatformIO commands, Serial output guide, unit test instructions

Closes #14