### PR TITLE
feat: device registration trilogy (#17, #18, #19)

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -3,5 +3,5 @@
 #define WIFI_SSID     "your-ssid"
 #define WIFI_PASSWORD "your-password"
 
-#define SERVER_URL   "http://192.168.x.x:8080/readings"
+#define SERVER_URL   "http://192.168.x.x:8080"
 #define DEVICE_TOKEN "your-32-byte-hex-token"

--- a/include/nvs_store.h
+++ b/include/nvs_store.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Arduino.h>
+#include <Preferences.h>
+
+class NVSStore {
+public:
+  void   begin();
+  String get(const char* key);
+  void   set(const char* key, const String& value);
+  void   remove(const char* key);
+  void   clear();
+
+private:
+  Preferences _prefs;
+};
+
+extern NVSStore nvsStore;

--- a/include/provisioning.h
+++ b/include/provisioning.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <Arduino.h>
+
+enum class ActivationError { None, WifiFailed, InvalidCode, ServerError };
+
+void startProvisioning();
+ActivationError activateDevice(const String& provisionCode);

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -10,7 +10,7 @@ static bool doPost(const String& payload, int& statusCode) {
   if (deviceToken.isEmpty()) deviceToken = DEVICE_TOKEN;
 
   HTTPClient http;
-  http.begin(serverUrl);
+  http.begin(serverUrl + "/readings");
   http.addHeader("Content-Type", "application/json");
   http.addHeader("Authorization", "Bearer " + deviceToken);
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,12 +1,18 @@
 #include "http_client.h"
 #include <HTTPClient.h>
+#include "nvs_store.h"
 #include "config.h"
 
 static bool doPost(const String& payload, int& statusCode) {
+  String serverUrl    = nvsStore.get("server_url");
+  String deviceToken  = nvsStore.get("device_token");
+  if (serverUrl.isEmpty())   serverUrl   = SERVER_URL;
+  if (deviceToken.isEmpty()) deviceToken = DEVICE_TOKEN;
+
   HTTPClient http;
-  http.begin(SERVER_URL);
+  http.begin(serverUrl);
   http.addHeader("Content-Type", "application/json");
-  http.addHeader("Authorization", "Bearer " DEVICE_TOKEN);
+  http.addHeader("Authorization", "Bearer " + deviceToken);
 
   unsigned long start = millis();
   statusCode = http.POST(payload);

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -8,6 +8,10 @@ static bool doPost(const String& payload, int& statusCode) {
   String deviceToken  = nvsStore.get("device_token");
   if (serverUrl.isEmpty())   serverUrl   = SERVER_URL;
   if (deviceToken.isEmpty()) deviceToken = DEVICE_TOKEN;
+  if (serverUrl.startsWith("http://") && !serverUrl.startsWith("http://192.") &&
+      !serverUrl.startsWith("http://10.") && !serverUrl.startsWith("http://172.")) {
+    serverUrl.replace("http://", "https://");
+  }
 
   HTTPClient http;
   http.begin(serverUrl + "/readings");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,12 +2,18 @@
 #include <OneWire.h>
 #include <DallasTemperature.h>
 #include "pins.h"
+#include "nvs_store.h"
 #include "wifi_ntp.h"
 #include "senml.h"
 #include "http_client.h"
 
 OneWire oneWire(ONE_WIRE_PIN);
 DallasTemperature sensors(&oneWire);
+
+static void logNvsKey(const char* key) {
+  String val = nvsStore.get(key);
+  Serial.printf("  NVS %-14s %s\n", key, val.isEmpty() ? "MISSING" : "present");
+}
 
 float readTemperatureCelsius() {
   sensors.requestTemperatures();
@@ -22,6 +28,26 @@ float readTemperatureCelsius() {
 void setup() {
   Serial.begin(115200);
   Serial.println("FishHub firmware booting...");
+
+  nvsStore.begin();
+
+  Serial.println("NVS key status:");
+  logNvsKey("wifi_ssid");
+  logNvsKey("wifi_pass");
+  logNvsKey("server_url");
+  logNvsKey("device_token");
+
+  bool provisioned =
+    !nvsStore.get("wifi_ssid").isEmpty() &&
+    !nvsStore.get("wifi_pass").isEmpty() &&
+    !nvsStore.get("server_url").isEmpty() &&
+    !nvsStore.get("device_token").isEmpty();
+
+  if (!provisioned) {
+    Serial.println("One or more NVS keys missing — entering provisioning mode");
+    // startProvisioning() will be wired in #18 — device reboots after activation
+    while (true) delay(1000);
+  }
 
   connectWifi();
   waitForNtp();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <DallasTemperature.h>
 #include "pins.h"
 #include "nvs_store.h"
+#include "provisioning.h"
 #include "wifi_ntp.h"
 #include "senml.h"
 #include "http_client.h"
@@ -45,8 +46,7 @@ void setup() {
 
   if (!provisioned) {
     Serial.println("One or more NVS keys missing — entering provisioning mode");
-    // startProvisioning() will be wired in #18 — device reboots after activation
-    while (true) delay(1000);
+    startProvisioning(); // never returns — device reboots after activation
   }
 
   connectWifi();

--- a/src/nvs_store.cpp
+++ b/src/nvs_store.cpp
@@ -1,0 +1,23 @@
+#include "nvs_store.h"
+
+NVSStore nvsStore;
+
+void NVSStore::begin() {
+  _prefs.begin("fishhub", false);
+}
+
+String NVSStore::get(const char* key) {
+  return _prefs.getString(key, "");
+}
+
+void NVSStore::set(const char* key, const String& value) {
+  _prefs.putString(key, value);
+}
+
+void NVSStore::remove(const char* key) {
+  _prefs.remove(key);
+}
+
+void NVSStore::clear() {
+  _prefs.clear();
+}

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -237,6 +237,11 @@ ActivationError activateDevice(const String& provisionCode) {
   String ssid      = nvsStore.get("wifi_ssid");
   String password  = nvsStore.get("wifi_pass");
   String serverUrl = nvsStore.get("server_url");
+  // Normalize to HTTPS — Railway and most hosted servers require it
+  if (serverUrl.startsWith("http://") && !serverUrl.startsWith("http://192.") &&
+      !serverUrl.startsWith("http://10.") && !serverUrl.startsWith("http://172.")) {
+    serverUrl.replace("http://", "https://");
+  }
 
   Serial.printf("Activation: connecting to Wi-Fi SSID=%s\n", ssid.c_str());
   WiFi.mode(WIFI_STA);

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -207,7 +207,7 @@ static void handleConfigure() {
 // ─── activation (#19) ────────────────────────────────────────────────────────
 
 static void restartAP() {
-  WiFi.mode(WIFI_AP);
+  WiFi.mode(WIFI_AP_STA);
   WiFi.softAP("FishHub-Setup");
 }
 
@@ -286,10 +286,11 @@ void startProvisioning() {
   scannedSSIDs.clear();
   scanDone = false;
 
-  xTaskCreatePinnedToCore(scanTask, "wifi_scan", 4096, nullptr, 1, nullptr, 0);
-
-  WiFi.mode(WIFI_AP);
+  // WIFI_AP_STA is required for WiFi.scanNetworks() to work while hosting an AP
+  WiFi.mode(WIFI_AP_STA);
   WiFi.softAP("FishHub-Setup");
+
+  xTaskCreatePinnedToCore(scanTask, "wifi_scan", 4096, nullptr, 1, nullptr, 0);
   Serial.printf("AP started — SSID: FishHub-Setup  IP: %s\n",
                 WiFi.softAPIP().toString().c_str());
 

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -107,13 +107,23 @@ static String buildForm(const String& errorMsg, const String& prefillSsid,
   // Password
   html += "<div class='field'>"
     "<label for='wifi_password'>Wi-Fi Password</label>"
-    "<input id='wifi_password' name='wifi_password' type='password' autocomplete='off'>"
+    "<div style='position:relative'>"
+    "<input id='wifi_password' name='wifi_password' type='password' "
+    "autocomplete='off' style='padding-right:2.5rem'>"
+    "<button type='button' onclick=\""
+      "var i=document.getElementById('wifi_password');"
+      "i.type=i.type==='password'?'text':'password';"
+      "this.textContent=i.type==='password'?'Show':'Hide';"
+    "\" style='position:absolute;right:0.5rem;top:50%;transform:translateY(-50%);"
+    "width:auto;margin:0;padding:0 0.5rem;background:none;color:#737373;"
+    "border:none;font-size:0.75rem;cursor:pointer'>Show</button>"
+    "</div>"
     "</div>";
 
   // Server URL
   html += "<div class='field'>"
     "<label for='server_url'>Server URL</label>"
-    "<input id='server_url' name='server_url' "
+    "<input id='server_url' name='server_url' autocapitalize='none' autocorrect='off' "
     "placeholder='http://192.168.1.10:8080' required value='" + prefillUrl + "'>"
     "</div>";
 

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -204,12 +204,81 @@ static void handleConfigure() {
   }
 }
 
-// ─── public API ──────────────────────────────────────────────────────────────
+// ─── activation (#19) ────────────────────────────────────────────────────────
 
-// Stub — replaced by full implementation in #19
+static void restartAP() {
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("FishHub-Setup");
+}
+
 ActivationError activateDevice(const String& provisionCode) {
-  (void)provisionCode;
-  return ActivationError::ServerError;
+  String ssid      = nvsStore.get("wifi_ssid");
+  String password  = nvsStore.get("wifi_pass");
+  String serverUrl = nvsStore.get("server_url");
+
+  Serial.printf("Activation: connecting to Wi-Fi SSID=%s\n", ssid.c_str());
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid.c_str(), password.c_str());
+
+  unsigned long start = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - start < 10000) {
+    delay(200);
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("Activation: Wi-Fi connect timed out");
+    restartAP();
+    return ActivationError::WifiFailed;
+  }
+  Serial.printf("Activation: Wi-Fi connected — IP: %s\n",
+                WiFi.localIP().toString().c_str());
+
+  String endpoint = serverUrl + "/devices/activate";
+  String body     = "{\"code\":\"" + provisionCode + "\"}";
+
+  auto doPost = [&](int& statusOut) -> String {
+    HTTPClient http;
+    http.begin(endpoint);
+    http.addHeader("Content-Type", "application/json");
+    statusOut = http.POST(body);
+    String resp = (statusOut > 0) ? http.getString() : "";
+    Serial.printf("Activation: POST %s -> %d\n", endpoint.c_str(), statusOut);
+    http.end();
+    return resp;
+  };
+
+  int status = 0;
+  String resp = doPost(status);
+
+  if (status <= 0 || status >= 500) {
+    Serial.println("Activation: server error, retrying once...");
+    delay(2000);
+    resp = doPost(status);
+  }
+
+  if (status >= 400 && status < 500) {
+    restartAP();
+    return ActivationError::InvalidCode;
+  }
+  if (status <= 0 || status >= 500) {
+    restartAP();
+    return ActivationError::ServerError;
+  }
+
+  // Parse token from response
+  JsonDocument doc;
+  DeserializationError jsonErr = deserializeJson(doc, resp);
+  if (jsonErr || !doc["token"].is<const char*>()) {
+    Serial.println("Activation: failed to parse token from response");
+    restartAP();
+    return ActivationError::ServerError;
+  }
+
+  String token = doc["token"].as<String>();
+  nvsStore.set("device_token", token);
+  Serial.println("Activation successful. Rebooting...");
+  delay(1000);
+  ESP.restart();
+  return ActivationError::None; // unreachable
 }
 
 void startProvisioning() {

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -1,0 +1,236 @@
+#include "provisioning.h"
+#include "nvs_store.h"
+#include <WiFi.h>
+#include <WebServer.h>
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <vector>
+
+// ─── shared scan state ───────────────────────────────────────────────────────
+
+static SemaphoreHandle_t  scanMutex;
+static std::vector<String> scannedSSIDs;
+static bool               scanDone = false;
+
+static void scanTask(void*) {
+  int n = WiFi.scanNetworks();
+  xSemaphoreTake(scanMutex, portMAX_DELAY);
+  for (int i = 0; i < n; i++) scannedSSIDs.push_back(WiFi.SSID(i));
+  scanDone = true;
+  xSemaphoreGive(scanMutex);
+  Serial.printf("Wi-Fi scan complete: %d network(s) found\n", n);
+  vTaskDelete(nullptr);
+}
+
+// ─── HTML ────────────────────────────────────────────────────────────────────
+
+static const char CSS[] =
+  "<style>"
+  "*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}"
+  "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+       "font-size:14px;background:#ffffff;color:#0a0a0a;"
+       "min-height:100dvh;display:flex;align-items:center;"
+       "justify-content:center;padding:1rem}"
+  ".card{background:#ffffff;border:1px solid #ebebeb;border-radius:0.625rem;"
+         "padding:1.5rem;width:100%;max-width:22rem}"
+  "h1{font-size:1.5rem;font-weight:600;text-align:center;margin-bottom:0.25rem}"
+  ".subtitle{color:#737373;font-size:0.875rem;text-align:center;margin-bottom:1.5rem}"
+  ".field{display:flex;flex-direction:column;gap:0.375rem;margin-bottom:1rem}"
+  "label{font-size:0.875rem;font-weight:500}"
+  "input,select{border:1px solid #ebebeb;border-radius:0.5rem;"
+                "padding:0.5rem 0.75rem;font-size:0.875rem;"
+                "font-family:inherit;outline:none;width:100%;background:#ffffff}"
+  "input:focus,select:focus{border-color:#b3b3b3;box-shadow:0 0 0 3px rgba(0,0,0,0.06)}"
+  ".code-input{font-family:monospace;font-size:1.25rem;"
+               "letter-spacing:0.15em;text-transform:uppercase;text-align:center}"
+  "button{width:100%;padding:0.5rem 1rem;background:#1a1a1a;color:#fafafa;"
+          "border:none;border-radius:0.5rem;font-size:0.875rem;font-weight:500;"
+          "font-family:inherit;cursor:pointer;margin-top:0.5rem}"
+  "button:hover{background:#333333}"
+  ".error{background:#fef2f2;border:1px solid #fecaca;border-radius:0.5rem;"
+          "padding:0.75rem;font-size:0.875rem;color:#b91c1c;margin-bottom:1rem}"
+  ".hint{font-size:0.75rem;color:#737373;margin-top:0.25rem}"
+  "</style>";
+
+static const char TOGGLE_SCRIPT[] =
+  "<script>"
+  "function toggleManual(sel){"
+    "var m=document.getElementById('wifi_ssid_manual');"
+    "m.style.display=sel.value==='__other__'?'block':'none';"
+    "m.required=sel.value==='__other__';"
+  "}"
+  "</script>";
+
+static String buildForm(const String& errorMsg, const String& prefillSsid,
+                        const String& prefillUrl) {
+  String html = "<!DOCTYPE html><html lang='en'><head>"
+    "<meta charset='UTF-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1.0'>"
+    "<title>FishHub Setup</title>";
+  html += CSS;
+  html += "</head><body><div class='card'>"
+    "<h1>FishHub</h1>"
+    "<p class='subtitle'>Connect your device</p>";
+
+  if (errorMsg.length() > 0) {
+    html += "<div class='error'>" + errorMsg + "</div>";
+  }
+
+  html += "<form method='POST' action='/configure'>";
+
+  // Wi-Fi network field
+  html += "<div class='field'><label for='wifi_ssid'>Wi-Fi Network</label>";
+
+  xSemaphoreTake(scanMutex, portMAX_DELAY);
+  bool done = scanDone;
+  std::vector<String> ssids = scannedSSIDs;
+  xSemaphoreGive(scanMutex);
+
+  if (done && !ssids.empty()) {
+    html += "<select id='wifi_ssid' name='wifi_ssid' onchange='toggleManual(this)'>";
+    for (const auto& s : ssids) {
+      html += "<option value='" + s + "'";
+      if (s == prefillSsid) html += " selected";
+      html += ">" + s + "</option>";
+    }
+    html += "<option value='__other__'>Other (enter manually)</option>";
+    html += "</select>";
+    html += "<input id='wifi_ssid_manual' name='wifi_ssid_manual' "
+            "placeholder='Network name' autocomplete='off' "
+            "style='display:none;margin-top:0.5rem'>";
+  } else {
+    html += "<input name='wifi_ssid' placeholder='Scanning for networks\xe2\x80\xa6' "
+            "autocomplete='off' value='" + prefillSsid + "'>";
+  }
+  html += "</div>";
+
+  // Password
+  html += "<div class='field'>"
+    "<label for='wifi_password'>Wi-Fi Password</label>"
+    "<input id='wifi_password' name='wifi_password' type='password' autocomplete='off'>"
+    "</div>";
+
+  // Server URL
+  html += "<div class='field'>"
+    "<label for='server_url'>Server URL</label>"
+    "<input id='server_url' name='server_url' "
+    "placeholder='http://192.168.1.10:8080' required value='" + prefillUrl + "'>"
+    "</div>";
+
+  // Provisioning code
+  html += "<div class='field'>"
+    "<label for='provision_code'>Provisioning Code</label>"
+    "<input id='provision_code' name='provision_code' class='code-input' "
+    "maxlength='6' required autocomplete='off'>"
+    "</div>";
+
+  html += "<button type='submit'>Connect</button>"
+    "</form></div>";
+  html += TOGGLE_SCRIPT;
+  html += "</body></html>";
+  return html;
+}
+
+static String buildSuccess() {
+  String html = "<!DOCTYPE html><html lang='en'><head>"
+    "<meta charset='UTF-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1.0'>"
+    "<title>FishHub Setup</title>";
+  html += CSS;
+  html += "</head><body><div class='card'>"
+    "<h1>FishHub</h1>"
+    "<p class='subtitle' style='margin-bottom:0'>"
+    "Device connected. You can close this page.</p>"
+    "</div></body></html>";
+  return html;
+}
+
+// ─── WebServer + handlers ─────────────────────────────────────────────────────
+
+static WebServer server(80);
+
+static void handleRoot() {
+  server.send(200, "text/html", buildForm("", "", ""));
+}
+
+static void handleConfigure() {
+  // Resolve SSID from select or manual input
+  String ssid = server.arg("wifi_ssid");
+  if (ssid == "__other__") ssid = server.arg("wifi_ssid_manual");
+  ssid.trim();
+
+  String password   = server.arg("wifi_password");
+  String serverUrl  = server.arg("server_url");
+  String code       = server.arg("provision_code");
+  serverUrl.trim();
+  code.trim();
+
+  Serial.printf("Configure: ssid=%s server_url=%s code=%s\n",
+                ssid.c_str(), serverUrl.c_str(), code.c_str());
+
+  if (ssid.isEmpty() || password.isEmpty() || serverUrl.isEmpty() || code.isEmpty()) {
+    server.send(400, "text/html",
+      buildForm("All fields are required.", ssid, serverUrl));
+    return;
+  }
+
+  nvsStore.set("wifi_ssid",   ssid);
+  nvsStore.set("wifi_pass",   password);
+  nvsStore.set("server_url",  serverUrl);
+
+  ActivationError err = activateDevice(code);
+
+  switch (err) {
+    case ActivationError::None:
+      server.send(200, "text/html", buildSuccess());
+      delay(2000);
+      ESP.restart();
+      break;
+    case ActivationError::WifiFailed:
+      server.send(200, "text/html",
+        buildForm("Could not connect to Wi-Fi. Check the network name and password.",
+                  ssid, serverUrl));
+      break;
+    case ActivationError::InvalidCode:
+      server.send(200, "text/html",
+        buildForm("Invalid provisioning code. Generate a new one in the app.",
+                  ssid, serverUrl));
+      break;
+    case ActivationError::ServerError:
+      server.send(200, "text/html",
+        buildForm("Could not reach the server. Check the Server URL.",
+                  ssid, serverUrl));
+      break;
+  }
+}
+
+// ─── public API ──────────────────────────────────────────────────────────────
+
+// Stub — replaced by full implementation in #19
+ActivationError activateDevice(const String& provisionCode) {
+  (void)provisionCode;
+  return ActivationError::ServerError;
+}
+
+void startProvisioning() {
+  scanMutex = xSemaphoreCreateMutex();
+  scannedSSIDs.clear();
+  scanDone = false;
+
+  xTaskCreatePinnedToCore(scanTask, "wifi_scan", 4096, nullptr, 1, nullptr, 0);
+
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP("FishHub-Setup");
+  Serial.printf("AP started — SSID: FishHub-Setup  IP: %s\n",
+                WiFi.softAPIP().toString().c_str());
+
+  server.on("/",          HTTP_GET,  handleRoot);
+  server.on("/configure", HTTP_POST, handleConfigure);
+  server.begin();
+  Serial.println("Captive portal listening on port 80");
+
+  while (true) {
+    server.handleClient();
+    yield();
+  }
+}

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -131,6 +131,21 @@ static String buildForm(const String& errorMsg, const String& prefillSsid,
   return html;
 }
 
+static String buildConnecting() {
+  String html = "<!DOCTYPE html><html lang='en'><head>"
+    "<meta charset='UTF-8'>"
+    "<meta name='viewport' content='width=device-width,initial-scale=1.0'>"
+    "<title>FishHub Setup</title>";
+  html += CSS;
+  html += "</head><body><div class='card'>"
+    "<h1>FishHub</h1>"
+    "<p class='subtitle'>Connecting to Wi-Fi and activating your device&hellip;</p>"
+    "<p class='hint' style='text-align:center;margin-top:1rem'>"
+    "This may take up to 15 seconds. The device will reboot when done.</p>"
+    "</div></body></html>";
+  return html;
+}
+
 static String buildSuccess() {
   String html = "<!DOCTYPE html><html lang='en'><head>"
     "<meta charset='UTF-8'>"
@@ -148,6 +163,7 @@ static String buildSuccess() {
 // ─── WebServer + handlers ─────────────────────────────────────────────────────
 
 static WebServer server(80);
+static bool pendingRestart = false;
 
 static void handleRoot() {
   server.send(200, "text/html", buildForm("", "", ""));
@@ -178,14 +194,18 @@ static void handleConfigure() {
   nvsStore.set("wifi_pass",   password);
   nvsStore.set("server_url",  serverUrl);
 
+  // Send a "connecting" page immediately so the browser has a response
+  // before we drop the AP to connect to the user's Wi-Fi network.
+  server.send(200, "text/html", buildConnecting());
+  server.client().flush();
+  delay(500);
+
   ActivationError err = activateDevice(code);
 
+  // activateDevice reboots on success — only error paths reach here.
+  // The AP is restarted inside activateDevice() before returning,
+  // so we can serve the error page normally.
   switch (err) {
-    case ActivationError::None:
-      server.send(200, "text/html", buildSuccess());
-      delay(2000);
-      ESP.restart();
-      break;
     case ActivationError::WifiFailed:
       server.send(200, "text/html",
         buildForm("Could not connect to Wi-Fi. Check the network name and password.",
@@ -200,6 +220,8 @@ static void handleConfigure() {
       server.send(200, "text/html",
         buildForm("Could not reach the server. Check the Server URL.",
                   ssid, serverUrl));
+      break;
+    default:
       break;
   }
 }

--- a/src/wifi_ntp.cpp
+++ b/src/wifi_ntp.cpp
@@ -2,6 +2,7 @@
 #include <WiFi.h>
 #include <time.h>
 #include "wifi_ntp.h"
+#include "nvs_store.h"
 #include "config.h"
 
 static const int WIFI_TIMEOUT_MS  = 10000;
@@ -9,9 +10,14 @@ static const int WIFI_MAX_RETRIES = 3;
 static const int NTP_TIMEOUT_MS   = 10000;
 
 void connectWifi() {
+  String ssid     = nvsStore.get("wifi_ssid");
+  String password = nvsStore.get("wifi_pass");
+  if (ssid.isEmpty())     ssid     = WIFI_SSID;
+  if (password.isEmpty()) password = WIFI_PASSWORD;
+
   for (int attempt = 1; attempt <= WIFI_MAX_RETRIES; attempt++) {
     Serial.printf("Wi-Fi connecting (attempt %d/%d)...\n", attempt, WIFI_MAX_RETRIES);
-    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    WiFi.begin(ssid.c_str(), password.c_str());
 
     unsigned long start = millis();
     while (WiFi.status() != WL_CONNECTED && millis() - start < WIFI_TIMEOUT_MS) {


### PR DESCRIPTION
## Summary

Implements the full device registration flow across three sequential issues on a single branch.

### #17 — NVS storage wrapper
- `NVSStore` class wrapping `Preferences` under namespace `"fishhub"`; global `nvsStore` instance
- `wifi_ntp.cpp`: reads `wifi_ssid`/`wifi_pass` from NVS, falls back to `config.h` defines
- `http_client.cpp`: reads `server_url`/`device_token` from NVS, falls back to `config.h` defines
- `main.cpp`: calls `nvsStore.begin()` on boot, logs key presence, branches to provisioning if any key is missing

### #18 — Captive portal with dual-core Wi-Fi scan
- `startProvisioning()`: launches `scanTask` on core 0 (FreeRTOS), switches to AP mode (`"FishHub-Setup"`), starts `WebServer` on port 80
- `GET /`: styled HTML form; renders `<select>` with scanned SSIDs once scan completes, plain `<input>` with placeholder while scanning; "Other (enter manually)" option
- `POST /configure`: validates fields, saves credentials to NVS, calls `activateDevice()`, renders success or per-error message
- HTML/CSS inlined, matching FishHub web app design tokens

### #19 — Wi-Fi connect and token activation
- `activateDevice()`: connects to Wi-Fi (10s timeout), POSTs to `<server_url>/devices/activate`, retries once on 5xx/network error, parses token with ArduinoJson, saves to NVS, reboots
- Restarts AP before returning on any failure so the user's browser stays connected
- Returns `WifiFailed`, `InvalidCode`, or `ServerError` on each failure path

## Test plan
- [x] `pio run` — clean build, no warnings from project code
- [ ] Flash and verify Serial output: NVS key status logged on boot, AP starts, scan completes
- [ ] Connect to `FishHub-Setup`, open `192.168.4.1`, submit form with valid credentials and provisioning code from web app
- [ ] Verify device reboots into normal mode and posts readings

> Requires `fishhub-oss/fishhub-server#33` deployed for end-to-end activation testing.

Closes #17
Closes #18
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)