### PR TITLE
feat: device reconfiguration via boot button hold

### DIFF
--- a/include/pins.h
+++ b/include/pins.h
@@ -1,3 +1,4 @@
 #pragma once
 
-#define ONE_WIRE_PIN 4
+#define ONE_WIRE_PIN     4
+#define RESET_BUTTON_PIN 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,26 +11,57 @@
 OneWire oneWire(ONE_WIRE_PIN);
 DallasTemperature sensors(&oneWire);
 
-static void logNvsKey(const char* key) {
+static void logNvsKey(const char *key)
+{
   String val = nvsStore.get(key);
   Serial.printf("  NVS %-14s %s\n", key, val.isEmpty() ? "MISSING" : "present");
 }
 
-float readTemperatureCelsius() {
+// Returns true if the given pin is held LOW for the entire durationMs window.
+static bool buttonHeldOnBoot(uint8_t pin, unsigned long durationMs)
+{
+  pinMode(pin, INPUT_PULLUP);
+  if (digitalRead(pin) == HIGH)
+    return false; // not held at all
+
+  unsigned long start = millis();
+  while (millis() - start < durationMs)
+  {
+    delay(50);
+    if (digitalRead(pin) == HIGH)
+    {
+      Serial.println("Reconfiguration: button released early — ignoring");
+      return false;
+    }
+  }
+  Serial.println("Reconfiguration: button hold detected");
+  return true;
+}
+
+float readTemperatureCelsius()
+{
   sensors.requestTemperatures();
   float temp = sensors.getTempCByIndex(0);
-  if (temp == DEVICE_DISCONNECTED_C) {
+  if (temp == DEVICE_DISCONNECTED_C)
+  {
     Serial.println("Sensor read error: DS18B20 disconnected or CRC failure");
     return NAN;
   }
   return temp;
 }
 
-void setup() {
+void setup()
+{
   Serial.begin(115200);
   Serial.println("FishHub firmware booting...");
 
   nvsStore.begin();
+
+  if (buttonHeldOnBoot(RESET_BUTTON_PIN, 3000))
+  {
+    Serial.println("Entering reconfiguration mode...");
+    startProvisioning(); // never returns
+  }
 
   Serial.println("NVS key status:");
   logNvsKey("wifi_ssid");
@@ -39,12 +70,13 @@ void setup() {
   logNvsKey("device_token");
 
   bool provisioned =
-    !nvsStore.get("wifi_ssid").isEmpty() &&
-    !nvsStore.get("wifi_pass").isEmpty() &&
-    !nvsStore.get("server_url").isEmpty() &&
-    !nvsStore.get("device_token").isEmpty();
+      !nvsStore.get("wifi_ssid").isEmpty() &&
+      !nvsStore.get("wifi_pass").isEmpty() &&
+      !nvsStore.get("server_url").isEmpty() &&
+      !nvsStore.get("device_token").isEmpty();
 
-  if (!provisioned) {
+  if (!provisioned)
+  {
     Serial.println("One or more NVS keys missing — entering provisioning mode");
     startProvisioning(); // never returns — device reboots after activation
   }
@@ -54,16 +86,21 @@ void setup() {
 
   sensors.begin();
   int deviceCount = sensors.getDeviceCount();
-  if (deviceCount == 0) {
+  if (deviceCount == 0)
+  {
     Serial.println("No DS18B20 found on OneWire bus");
-  } else {
+  }
+  else
+  {
     Serial.printf("%d DS18B20 sensor(s) found\n", deviceCount);
   }
 }
 
-void loop() {
+void loop()
+{
   float temp = readTemperatureCelsius();
-  if (!isnan(temp)) {
+  if (!isnan(temp))
+  {
     Serial.printf("Temp: %.2f °C\n", temp);
     String payload = buildSenMLPayload(temp, time(nullptr));
     postReading(payload);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,34 +18,18 @@ static void logNvsKey(const char *key)
 }
 
 // Returns true if the given pin is held LOW for durationMs continuous milliseconds.
-// Waits up to 500ms for the button to be pressed before starting the hold timer.
-static bool buttonHeldOnBoot(uint8_t pin, unsigned long durationMs)
+static bool buttonHeld(uint8_t pin, unsigned long durationMs)
 {
-  pinMode(pin, INPUT_PULLUP);
+  if (digitalRead(pin) == HIGH)
+    return false;
 
-  // Wait up to 500ms for the button to be pressed
-  unsigned long waitStart = millis();
-  while (digitalRead(pin) == HIGH)
-  {
-    if (millis() - waitStart > 500)
-      return false; // button not pressed within window
-    delay(10);
-  }
-
-  Serial.println("Reconfiguration: button pressed — hold for 3 seconds to reconfigure");
-
-  // Button is now LOW — require it held for the full durationMs
-  unsigned long holdStart = millis();
-  while (millis() - holdStart < durationMs)
+  unsigned long start = millis();
+  while (millis() - start < durationMs)
   {
     delay(50);
     if (digitalRead(pin) == HIGH)
-    {
-      Serial.println("Reconfiguration: button released early — ignoring");
       return false;
-    }
   }
-  Serial.println("Reconfiguration: hold detected");
   return true;
 }
 
@@ -67,12 +51,7 @@ void setup()
   Serial.println("FishHub firmware booting...");
 
   nvsStore.begin();
-
-  if (buttonHeldOnBoot(RESET_BUTTON_PIN, 3000))
-  {
-    Serial.println("Entering reconfiguration mode...");
-    startProvisioning(); // never returns
-  }
+  pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
 
   Serial.println("NVS key status:");
   logNvsKey("wifi_ssid");
@@ -109,6 +88,12 @@ void setup()
 
 void loop()
 {
+  if (buttonHeld(RESET_BUTTON_PIN, 3000))
+  {
+    Serial.println("Button held — entering reconfiguration mode...");
+    startProvisioning(); // never returns
+  }
+
   float temp = readTemperatureCelsius();
   if (!isnan(temp))
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,15 +17,26 @@ static void logNvsKey(const char *key)
   Serial.printf("  NVS %-14s %s\n", key, val.isEmpty() ? "MISSING" : "present");
 }
 
-// Returns true if the given pin is held LOW for the entire durationMs window.
+// Returns true if the given pin is held LOW for durationMs continuous milliseconds.
+// Waits up to 500ms for the button to be pressed before starting the hold timer.
 static bool buttonHeldOnBoot(uint8_t pin, unsigned long durationMs)
 {
   pinMode(pin, INPUT_PULLUP);
-  if (digitalRead(pin) == HIGH)
-    return false; // not held at all
 
-  unsigned long start = millis();
-  while (millis() - start < durationMs)
+  // Wait up to 500ms for the button to be pressed
+  unsigned long waitStart = millis();
+  while (digitalRead(pin) == HIGH)
+  {
+    if (millis() - waitStart > 500)
+      return false; // button not pressed within window
+    delay(10);
+  }
+
+  Serial.println("Reconfiguration: button pressed — hold for 3 seconds to reconfigure");
+
+  // Button is now LOW — require it held for the full durationMs
+  unsigned long holdStart = millis();
+  while (millis() - holdStart < durationMs)
   {
     delay(50);
     if (digitalRead(pin) == HIGH)
@@ -34,7 +45,7 @@ static bool buttonHeldOnBoot(uint8_t pin, unsigned long durationMs)
       return false;
     }
   }
-  Serial.println("Reconfiguration: button hold detected");
+  Serial.println("Reconfiguration: hold detected");
   return true;
 }
 

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -61,16 +61,19 @@ static const char TOGGLE_SCRIPT[] =
   "}"
   "</script>";
 
+// reconfiguring = device already has a token; omit provisioning code field
 static String buildForm(const String& errorMsg, const String& prefillSsid,
-                        const String& prefillUrl) {
+                        const String& prefillUrl, bool reconfiguring) {
   String html = "<!DOCTYPE html><html lang='en'><head>"
     "<meta charset='UTF-8'>"
     "<meta name='viewport' content='width=device-width,initial-scale=1.0'>"
     "<title>FishHub Setup</title>";
   html += CSS;
   html += "</head><body><div class='card'>"
-    "<h1>FishHub</h1>"
-    "<p class='subtitle'>Connect your device</p>";
+    "<h1>FishHub</h1>";
+  html += reconfiguring
+    ? "<p class='subtitle'>Update your device settings</p>"
+    : "<p class='subtitle'>Connect your device</p>";
 
   if (errorMsg.length() > 0) {
     html += "<div class='error'>" + errorMsg + "</div>";
@@ -127,15 +130,19 @@ static String buildForm(const String& errorMsg, const String& prefillSsid,
     "placeholder='http://192.168.1.10:8080' required value='" + prefillUrl + "'>"
     "</div>";
 
-  // Provisioning code
-  html += "<div class='field'>"
-    "<label for='provision_code'>Provisioning Code</label>"
-    "<input id='provision_code' name='provision_code' class='code-input' "
-    "maxlength='6' required autocomplete='off'>"
-    "</div>";
+  // Provisioning code — only shown on fresh provisioning
+  if (!reconfiguring) {
+    html += "<div class='field'>"
+      "<label for='provision_code'>Provisioning Code</label>"
+      "<input id='provision_code' name='provision_code' class='code-input' "
+      "maxlength='6' required autocomplete='off'>"
+      "</div>";
+  }
 
-  html += "<button type='submit'>Connect</button>"
-    "</form></div>";
+  html += reconfiguring
+    ? "<button type='submit'>Save &amp; Reconnect</button>"
+    : "<button type='submit'>Connect</button>";
+  html += "</form></div>";
   html += TOGGLE_SCRIPT;
   html += "</body></html>";
   return html;
@@ -173,10 +180,11 @@ static String buildSuccess() {
 // ─── WebServer + handlers ─────────────────────────────────────────────────────
 
 static WebServer server(80);
-static bool pendingRestart = false;
+static bool      reconfiguring = false;
 
 static void handleRoot() {
-  server.send(200, "text/html", buildForm("", "", ""));
+  String prefillUrl = reconfiguring ? nvsStore.get("server_url") : "";
+  server.send(200, "text/html", buildForm("", "", prefillUrl, reconfiguring));
 }
 
 static void handleConfigure() {
@@ -185,24 +193,48 @@ static void handleConfigure() {
   if (ssid == "__other__") ssid = server.arg("wifi_ssid_manual");
   ssid.trim();
 
-  String password   = server.arg("wifi_password");
-  String serverUrl  = server.arg("server_url");
-  String code       = server.arg("provision_code");
+  String password  = server.arg("wifi_password");
+  String serverUrl = server.arg("server_url");
   serverUrl.trim();
+
+  if (reconfiguring) {
+    Serial.printf("Reconfigure: ssid=%s server_url=%s\n",
+                  ssid.c_str(), serverUrl.c_str());
+
+    if (ssid.isEmpty() || password.isEmpty() || serverUrl.isEmpty()) {
+      server.send(200, "text/html",
+        buildForm("All fields are required.", ssid, serverUrl, true));
+      return;
+    }
+
+    nvsStore.set("wifi_ssid",  ssid);
+    nvsStore.set("wifi_pass",  password);
+    nvsStore.set("server_url", serverUrl);
+
+    server.send(200, "text/html", buildConnecting());
+    server.client().flush();
+    delay(500);
+    Serial.println("Reconfiguration saved. Rebooting...");
+    ESP.restart();
+    return;
+  }
+
+  // Fresh provisioning path
+  String code = server.arg("provision_code");
   code.trim();
 
   Serial.printf("Configure: ssid=%s server_url=%s code=%s\n",
                 ssid.c_str(), serverUrl.c_str(), code.c_str());
 
   if (ssid.isEmpty() || password.isEmpty() || serverUrl.isEmpty() || code.isEmpty()) {
-    server.send(400, "text/html",
-      buildForm("All fields are required.", ssid, serverUrl));
+    server.send(200, "text/html",
+      buildForm("All fields are required.", ssid, serverUrl, false));
     return;
   }
 
-  nvsStore.set("wifi_ssid",   ssid);
-  nvsStore.set("wifi_pass",   password);
-  nvsStore.set("server_url",  serverUrl);
+  nvsStore.set("wifi_ssid",  ssid);
+  nvsStore.set("wifi_pass",  password);
+  nvsStore.set("server_url", serverUrl);
 
   // Send a "connecting" page immediately so the browser has a response
   // before we drop the AP to connect to the user's Wi-Fi network.
@@ -219,17 +251,17 @@ static void handleConfigure() {
     case ActivationError::WifiFailed:
       server.send(200, "text/html",
         buildForm("Could not connect to Wi-Fi. Check the network name and password.",
-                  ssid, serverUrl));
+                  ssid, serverUrl, false));
       break;
     case ActivationError::InvalidCode:
       server.send(200, "text/html",
         buildForm("Invalid provisioning code. Generate a new one in the app.",
-                  ssid, serverUrl));
+                  ssid, serverUrl, false));
       break;
     case ActivationError::ServerError:
       server.send(200, "text/html",
         buildForm("Could not reach the server. Check the Server URL.",
-                  ssid, serverUrl));
+                  ssid, serverUrl, false));
       break;
     default:
       break;
@@ -319,6 +351,10 @@ ActivationError activateDevice(const String& provisionCode) {
 }
 
 void startProvisioning() {
+  // Reconfiguring if the device already has a token — no provisioning code needed
+  reconfiguring = !nvsStore.get("device_token").isEmpty();
+  Serial.printf("Provisioning mode: %s\n", reconfiguring ? "reconfiguration" : "fresh");
+
   scanMutex = xSemaphoreCreateMutex();
   scannedSSIDs.clear();
   scanDone = false;


### PR DESCRIPTION
## Summary

- Defines `RESET_BUTTON_PIN 0` (BOOT button, active LOW) in `include/pins.h`
- Adds `buttonHeldOnBoot(pin, durationMs)` in `main.cpp` — polls every 50ms, returns true only if held LOW the entire duration; serial logs hold/early-release
- In `setup()`, checks the button after `nvsStore.begin()` and before the provisioned check — if held, calls `startProvisioning()` without clearing NVS
- `startProvisioning()` detects reconfiguration mode by checking for an existing `device_token` in NVS
- In reconfiguration mode: form shows Wi-Fi + server URL only (no provisioning code field, subtitle says "Update your device settings", button says "Save & Reconnect"); on submit saves credentials and reboots — no server call
- In fresh provisioning mode: existing flow unchanged

## Test plan

- [ ] Hold BOOT button on boot for 3s → AP starts, form shows without provisioning code field
- [ ] Release BOOT button before 3s → normal boot
- [ ] Reconfigure with new Wi-Fi credentials → device reboots and connects normally
- [ ] Fresh flash (no NVS token) → full form with provisioning code shown

Closes #21