### PR TITLE
feat: switch SenML output to flat RFC 8428 sibling records

### DIFF
--- a/include/peripheral.h
+++ b/include/peripheral.h
@@ -22,9 +22,9 @@ public:
   // Called when intervalMs() has elapsed. Returns true if there is a new reading/state.
   virtual bool tick(time_t now) = 0;
 
-  // Appends one or more SenML entries to the "e" array of the base record.
+  // Appends one or more SenML sibling records to the top-level records array.
   // Only called when tick() returned true.
-  virtual void appendSenML(JsonArray& entries, time_t now) = 0;
+  virtual void appendSenML(JsonArray& records, time_t now) = 0;
 
   // Entry point for inbound MQTT commands. Sensors may leave this as the default no-op.
   virtual void applyCommand(JsonObjectConst cmd) {}

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -17,17 +17,13 @@ void PeripheralManager::beginAll() {
 String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
   JsonDocument doc;
   JsonArray records = doc.to<JsonArray>();
-  JsonObject base   = records.add<JsonObject>();
-  base["bn"] = "fishhub/device/";
-  base["bt"] = (long)now;
-  JsonArray entries = base["e"].to<JsonArray>();
 
   bool anyData = false;
   for (auto& e : _entries) {
     if (nowMs - e.lastTickedAt >= e.peripheral->intervalMs()) {
       e.lastTickedAt = nowMs;
       if (e.peripheral->tick(now)) {
-        e.peripheral->appendSenML(entries, now);
+        e.peripheral->appendSenML(records, now);
         anyData = true;
       }
     }
@@ -35,9 +31,19 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
 
   if (!anyData) return String{};
 
-  String out;
-  serializeJson(doc, out);
-  return out;
+  // Prepend base record now that we know there is data
+  JsonDocument out;
+  JsonArray result = out.to<JsonArray>();
+  JsonObject base  = result.add<JsonObject>();
+  base["bn"] = "fishhub/device/";
+  base["bt"] = (long)now;
+  for (JsonObject r : records) {
+    result.add(r);
+  }
+
+  String payload;
+  serializeJson(out, payload);
+  return payload;
 
 }
 

--- a/src/peripherals/ds18b20_sensor.cpp
+++ b/src/peripherals/ds18b20_sensor.cpp
@@ -21,9 +21,9 @@ bool DS18B20Sensor::tick(time_t /*now*/) {
   return true;
 }
 
-void DS18B20Sensor::appendSenML(JsonArray& entries, time_t /*now*/) {
-  JsonObject e = entries.add<JsonObject>();
-  e["n"] = "temperature";
-  e["u"] = "Cel";
-  e["v"] = _lastTemp;
+void DS18B20Sensor::appendSenML(JsonArray& records, time_t /*now*/) {
+  JsonObject r = records.add<JsonObject>();
+  r["n"] = "temperature";
+  r["u"] = "Cel";
+  r["v"] = _lastTemp;
 }

--- a/src/peripherals/ds18b20_sensor.h
+++ b/src/peripherals/ds18b20_sensor.h
@@ -11,7 +11,7 @@ public:
   void     begin() override;
   uint32_t intervalMs() const override { return _intervalMs; }
   bool     tick(time_t now) override;
-  void     appendSenML(JsonArray& entries, time_t now) override;
+  void     appendSenML(JsonArray& records, time_t now) override;
   const char* name() const override { return "temperature"; }
 
 private:

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -19,10 +19,10 @@ public:
     return true;
   }
 
-  void appendSenML(JsonArray& entries, time_t /*now*/) override {
-    JsonObject e = entries.add<JsonObject>();
-    e["n"] = _name;
-    e["v"] = (float)tickCount;
+  void appendSenML(JsonArray& records, time_t /*now*/) override {
+    JsonObject r = records.add<JsonObject>();
+    r["n"] = _name;
+    r["v"] = (float)tickCount;
   }
 
   void applyCommand(JsonObjectConst cmd) override {
@@ -87,6 +87,30 @@ void test_two_peripherals_tick_independently(void) {
   TEST_ASSERT_EQUAL_INT(1, slow.tickCount);
 }
 
+void test_tickAll_produces_flat_senml(void) {
+  PeripheralManager mgr;
+  MockPeripheral p("temperature", 1000);
+  mgr.add(&p);
+  mgr.beginAll();
+
+  String out = mgr.tickAll(1745000000, 1000);
+  TEST_ASSERT_FALSE(out.empty());
+
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, out);
+  TEST_ASSERT_EQUAL_INT(DeserializationError::Ok, err.code());
+
+  JsonArray arr = doc.as<JsonArray>();
+  // First element must be base record with bn and bt
+  TEST_ASSERT_EQUAL_STRING("fishhub/device/", arr[0]["bn"].as<const char*>());
+  TEST_ASSERT_EQUAL_INT(1745000000, arr[0]["bt"].as<long>());
+  // Second element must be a measurement record (no bn/bt)
+  TEST_ASSERT_EQUAL_STRING("temperature", arr[1]["n"].as<const char*>());
+  TEST_ASSERT_TRUE(arr[1]["v"].is<float>());
+  // No "e" key anywhere
+  TEST_ASSERT_TRUE(arr[0]["e"].isNull());
+}
+
 void test_dispatch_command_routes_by_name(void) {
   PeripheralManager mgr;
   MockPeripheral a("relay", 1000);
@@ -113,6 +137,7 @@ int main(void) {
   RUN_TEST(test_not_ticked_before_interval);
   RUN_TEST(test_ticked_after_interval);
   RUN_TEST(test_two_peripherals_tick_independently);
+  RUN_TEST(test_tickAll_produces_flat_senml);
   RUN_TEST(test_dispatch_command_routes_by_name);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- `appendSenML()` signature changed: receives the top-level records array, appends sibling records directly
- `PeripheralManager::tickAll()` prepends the base record (`bn`, `bt`) only when at least one peripheral produced data
- `DS18B20Sensor::appendSenML()` updated to append a sibling record
- New native test `test_tickAll_produces_flat_senml` asserts the wire format: first element has `bn`/`bt`, second has `n`/`v`, no `"e"` key

## Wire format

Before: `[{"bn":"fishhub/device/","bt":1745000000,"e":[{"n":"temperature","u":"Cel","v":25.3}]}]`
After:  `[{"bn":"fishhub/device/","bt":1745000000},{"n":"temperature","u":"Cel","v":25.3}]`

## Test plan

- [x] `pio test -e native` — 5/5 passing
- [x] `pio run` — ESP32 build clean
- [ ] Flash and verify flat format in Serial output
- [ ] End-to-end with server PR fishhub-oss/fishhub-server#48

Closes #29