### PR TITLE
feat: relay actuator, schedule helper, and MQTT command delivery

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -3,8 +3,15 @@
 #define WIFI_SSID     "your-ssid"
 #define WIFI_PASSWORD "your-password"
 
-#define SERVER_URL   "http://192.168.x.x:8080"
-#define DEVICE_TOKEN "your-32-byte-hex-token"
+// Backend base URL (no trailing slash)
+#define SERVER_URL   "https://your-server.example.com"
 
-// How often the DS18B20 sensor is read, in milliseconds (default: 30000).
+// MQTT broker — format: mqtts://host:port
+#define MQTT_URL     "mqtts://your-broker.hivemq.cloud:8883"
+
+// Device credentials — populated automatically by provisioning; set manually for dev
+#define DEVICE_ID    ""
+#define DEVICE_TOKEN ""
+
+// Sensor polling intervals (milliseconds)
 #define DS18B20_INTERVAL_MS 30000

--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Arduino.h>
+#include <WiFiClientSecure.h>
+#include <PubSubClient.h>
+#include "peripheral_manager.h"
+
+class FishHubMqttClient {
+public:
+  void begin(PeripheralManager& manager);
+  void loop();
+
+private:
+  void connect();
+  void onMessage(char* topic, byte* payload, unsigned int len);
+
+  WiFiClientSecure  _tlsClient;
+  PubSubClient      _client;
+  PeripheralManager* _manager = nullptr;
+  String            _deviceId;
+  String            _deviceJwt;
+  unsigned long     _lastConnectAttempt = 0;
+};

--- a/include/peripheral.h
+++ b/include/peripheral.h
@@ -29,6 +29,12 @@ public:
   // Entry point for inbound MQTT commands. Sensors may leave this as the default no-op.
   virtual void applyCommand(JsonObjectConst cmd) {}
 
+  // Returns true if retained/redelivered commands should always be re-applied (default).
+  // Idempotent peripherals (schedules, state) return true.
+  // One-shot peripherals (feeder, doser) override to false — the MQTT client will
+  // deduplicate by persisting the last processed command ID in NVS.
+  virtual bool replayCommand() const { return true; }
+
   // Unique name — used as MQTT topic segment and SenML field name prefix.
   virtual const char* name() const = 0;
 };

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -31,6 +31,9 @@ public:
   // Routes an inbound MQTT command to the peripheral matching name().
   void dispatchCommand(const String& name, JsonObjectConst cmd);
 
+  // Returns the peripheral with the given name, or nullptr if not found.
+  Peripheral* find(const String& name);
+
 private:
   std::vector<PeripheralEntry> _entries;
 };

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <cstdint>
+#include <ctime>
+#endif
+
+#include <ArduinoJson.h>
+#include <vector>
+
+class Schedule {
+public:
+  // Parses an array of ["HH:MM","HH:MM"] window pairs.
+  // Clears any active override.
+  void loadWindows(JsonArrayConst windows);
+
+  // Returns true if now falls within any stored window.
+  // Handles overnight windows (e.g. 22:00–06:00) correctly.
+  bool isActive(time_t now) const;
+
+  // Forces a fixed state regardless of windows until the next loadWindows() call.
+  void setOverride(bool state);
+
+  bool hasOverride() const { return _overridden; }
+
+private:
+  struct Window {
+    uint16_t onMinutes;
+    uint16_t offMinutes;
+  };
+
+  static uint16_t parseMinutes(const char* hhmm);
+
+  std::vector<Window> _windows;
+  bool _overridden    = false;
+  bool _overrideState = false;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ lib_deps =
   paulstoffregen/OneWire @ ^2.3.8
   milesburton/DallasTemperature @ ^3.11.0
   bblanchon/ArduinoJson @ ^7.3.1
+  knolleary/PubSubClient @ ^2.8
 
 [env:native]
 platform = native

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,14 +4,17 @@
 #include "provisioning.h"
 #include "wifi_ntp.h"
 #include "http_client.h"
+#include "mqtt_client.h"
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
+#include "peripherals/relay_actuator.h"
 
 #ifndef DS18B20_INTERVAL_MS
 #define DS18B20_INTERVAL_MS 30000
 #endif
 
 PeripheralManager manager;
+FishHubMqttClient mqttClient;
 
 static void logNvsKey(const char* key) {
   String val = nvsStore.get(key);
@@ -39,12 +42,14 @@ void setup() {
   logNvsKey("wifi_ssid");
   logNvsKey("wifi_pass");
   logNvsKey("server_url");
+  logNvsKey("device_id");
   logNvsKey("device_jwt");
 
   bool provisioned =
     !nvsStore.get("wifi_ssid").isEmpty() &&
     !nvsStore.get("wifi_pass").isEmpty() &&
     !nvsStore.get("server_url").isEmpty() &&
+    !nvsStore.get("device_id").isEmpty() &&
     !nvsStore.get("device_jwt").isEmpty();
 
   if (!provisioned) {
@@ -56,7 +61,10 @@ void setup() {
   waitForNtp();
 
   manager.add(new DS18B20Sensor(ONE_WIRE_PIN, DS18B20_INTERVAL_MS));
+  manager.add(new RelayActuator("light", RELAY_LIGHT_PIN));
   manager.beginAll();
+
+  mqttClient.begin(manager);
 }
 
 void loop() {
@@ -64,6 +72,8 @@ void loop() {
     Serial.println("Button held — entering reconfiguration mode...");
     startProvisioning(); // never returns
   }
+
+  mqttClient.loop();
 
   time_t now = time(nullptr);
   String payload = manager.tickAll(now, millis());

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -1,0 +1,125 @@
+#include "mqtt_client.h"
+#include "nvs_store.h"
+#include "config.h"
+#include <ArduinoJson.h>
+
+static const unsigned long RECONNECT_INTERVAL_MS = 5000;
+
+// Parse host and port out of "mqtts://host:port"
+static void parseMqttUrl(const String& url, String& host, uint16_t& port) {
+  int start = url.indexOf("://");
+  start = (start < 0) ? 0 : start + 3;
+  int colon = url.lastIndexOf(':');
+  if (colon > start) {
+    host = url.substring(start, colon);
+    port = (uint16_t)url.substring(colon + 1).toInt();
+  } else {
+    host = url.substring(start);
+    port = 8883;
+  }
+}
+
+void FishHubMqttClient::begin(PeripheralManager& manager) {
+  _manager = &manager;
+
+  _deviceId  = nvsStore.get("device_id");
+  _deviceJwt = nvsStore.get("device_jwt");
+  if (_deviceId.isEmpty())  _deviceId  = DEVICE_ID;
+  if (_deviceJwt.isEmpty()) _deviceJwt = DEVICE_TOKEN;
+
+  String mqttUrl = nvsStore.get("mqtt_url");
+  if (mqttUrl.isEmpty()) mqttUrl = MQTT_URL;
+
+  String host;
+  uint16_t port;
+  parseMqttUrl(mqttUrl, host, port);
+
+  // PoC: skip certificate verification — see issue #27 for proper CA pinning
+  _tlsClient.setInsecure();
+
+  _client.setClient(_tlsClient);
+  _client.setServer(host.c_str(), port);
+  _client.setCallback([this](char* topic, byte* payload, unsigned int len) {
+    onMessage(topic, payload, len);
+  });
+
+  connect();
+}
+
+void FishHubMqttClient::loop() {
+  if (!_client.connected()) {
+    unsigned long now = millis();
+    if (now - _lastConnectAttempt >= RECONNECT_INTERVAL_MS) {
+      _lastConnectAttempt = now;
+      connect();
+    }
+  }
+  _client.loop();
+}
+
+void FishHubMqttClient::connect() {
+  if (_deviceId.isEmpty() || _deviceJwt.isEmpty()) {
+    Serial.println("MQTT: device_id or device_jwt missing — skipping connect");
+    return;
+  }
+
+  Serial.printf("MQTT: connecting as %s...\n", _deviceId.c_str());
+  // Authenticate with device JWT as password; broker verifies signature via JWKS
+  bool ok = _client.connect(
+    _deviceId.c_str(),  // client ID
+    _deviceId.c_str(),  // username (must match JWT sub for HiveMQ topic filter)
+    _deviceJwt.c_str()  // password — RS256 JWT verified by HiveMQ JWT IdP
+  );
+
+  if (!ok) {
+    Serial.printf("MQTT: connect failed, rc=%d\n", _client.state());
+    return;
+  }
+
+  String topic = "fishhub/" + _deviceId + "/commands/#";
+  _client.subscribe(topic.c_str());
+  Serial.printf("MQTT: connected, subscribed to %s\n", topic.c_str());
+}
+
+void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) {
+  // Extract peripheral name from last topic segment: fishhub/<id>/commands/<name>
+  String t(topic);
+  int lastSlash = t.lastIndexOf('/');
+  if (lastSlash < 0) return;
+  String peripheralName = t.substring(lastSlash + 1);
+
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, payload, len);
+  if (err) {
+    Serial.printf("MQTT: JSON parse error on topic %s: %s\n", topic, err.c_str());
+    return;
+  }
+
+  const char* cmdId = doc["id"];
+  if (!cmdId || strlen(cmdId) == 0) {
+    Serial.printf("MQTT: command missing 'id' field on topic %s — ignored\n", topic);
+    return;
+  }
+
+  // Find the peripheral to check its replay policy
+  Peripheral* peripheral = _manager->find(peripheralName);
+  if (!peripheral) {
+    Serial.printf("MQTT: no peripheral named '%s'\n", peripheralName.c_str());
+    return;
+  }
+
+  if (!peripheral->replayCommand()) {
+    // Non-replayable: check last processed ID in NVS
+    String nvsKey = String("cmd_") + peripheralName;
+    String lastId = nvsStore.get(nvsKey.c_str());
+    if (lastId == cmdId) {
+      Serial.printf("MQTT: duplicate command id=%s for %s — skipped\n",
+                    cmdId, peripheralName.c_str());
+      return;
+    }
+    nvsStore.set(nvsKey.c_str(), String(cmdId));
+  }
+
+  Serial.printf("MQTT: dispatching command id=%s to %s\n", cmdId, peripheralName.c_str());
+  _manager->dispatchCommand(peripheralName, doc.as<JsonObjectConst>());
+}

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -55,3 +55,10 @@ void PeripheralManager::dispatchCommand(const String& name, JsonObjectConst cmd)
     }
   }
 }
+
+Peripheral* PeripheralManager::find(const String& name) {
+  for (auto& e : _entries) {
+    if (name == e.peripheral->name()) return e.peripheral;
+  }
+  return nullptr;
+}

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -1,0 +1,41 @@
+#include "relay_actuator.h"
+#include <Arduino.h>
+
+RelayActuator::RelayActuator(const char* name, uint8_t pin)
+  : _name(name), _pin(pin) {}
+
+void RelayActuator::begin() {
+  pinMode(_pin, OUTPUT);
+  // Start de-energized (HIGH = off for active-low relay)
+  digitalWrite(_pin, HIGH);
+  _currentState = false;
+}
+
+bool RelayActuator::tick(time_t now) {
+  bool desired = _schedule.isActive(now);
+  if (desired != _currentState) {
+    // Active-low: LOW energizes the relay (on), HIGH de-energizes (off)
+    digitalWrite(_pin, desired ? LOW : HIGH);
+    _currentState = desired;
+    Serial.printf("Relay %s: %s\n", _name, desired ? "ON" : "OFF");
+  }
+  return true;
+}
+
+void RelayActuator::appendSenML(JsonArray& records, time_t /*now*/) {
+  JsonObject r = records.add<JsonObject>();
+  String n = String(_name) + "/state";
+  r["n"]  = n;
+  r["vb"] = _currentState;
+}
+
+void RelayActuator::applyCommand(JsonObjectConst cmd) {
+  const char* action = cmd["action"];
+  if (!action) return;
+
+  if (strcmp(action, "set") == 0) {
+    _schedule.setOverride(cmd["state"].as<bool>());
+  } else if (strcmp(action, "schedule") == 0) {
+    _schedule.loadWindows(cmd["windows"].as<JsonArrayConst>());
+  }
+}

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Arduino.h>
+#include "peripheral.h"
+#include "schedule.h"
+
+class RelayActuator : public Peripheral {
+public:
+  RelayActuator(const char* name, uint8_t pin);
+
+  void        begin() override;
+  uint32_t    intervalMs() const override { return 1000; }
+  bool        tick(time_t now) override;
+  void        appendSenML(JsonArray& records, time_t now) override;
+  void        applyCommand(JsonObjectConst cmd) override;
+  const char* name() const override { return _name; }
+
+  // Schedules are idempotent — retained messages should re-apply on reboot.
+  bool replayCommand() const override { return true; }
+
+private:
+  const char* _name;
+  uint8_t     _pin;
+  Schedule    _schedule;
+  bool        _currentState = false;
+};

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -363,11 +363,13 @@ ActivationError activateDevice(const String &provisionCode)
     return ActivationError::ServerError;
   }
 
-  // Parse token from response
+  // Parse response: { device_id, token }
   JsonDocument doc;
   DeserializationError jsonErr = deserializeJson(doc, resp);
-  String token = jsonErr ? String() : doc["token"].as<String>();
-  Serial.printf("Activation: token length=%d\n", token.length());
+  String token    = jsonErr ? String() : doc["token"].as<String>();
+  String deviceId = jsonErr ? String() : doc["device_id"].as<String>();
+  Serial.printf("Activation: token length=%d  device_id=%s\n",
+                token.length(), deviceId.isEmpty() ? "(missing)" : deviceId.c_str());
   if (token.isEmpty())
   {
     Serial.println("Activation: server returned empty token — DEVICE_JWT_PRIVATE_KEY not configured on server");
@@ -376,8 +378,10 @@ ActivationError activateDevice(const String &provisionCode)
   }
 
   nvsStore.set("device_jwt", token);
-  Serial.printf("Activation: device_jwt stored=%s\n",
-                nvsStore.get("device_jwt").isEmpty() ? "FAILED" : "OK");
+  if (!deviceId.isEmpty()) nvsStore.set("device_id", deviceId);
+  Serial.printf("Activation: device_jwt stored=%s  device_id stored=%s\n",
+                nvsStore.get("device_jwt").isEmpty() ? "FAILED" : "OK",
+                nvsStore.get("device_id").isEmpty() ? "FAILED" : "OK");
   Serial.println("Activation successful. Rebooting...");
   delay(1000);
   ESP.restart();

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -1,0 +1,50 @@
+#include "schedule.h"
+#include <cstring>
+#include <cstdlib>
+
+uint16_t Schedule::parseMinutes(const char* hhmm) {
+  if (!hhmm || strlen(hhmm) < 5) return 0;
+  uint16_t h = (uint16_t)atoi(hhmm);
+  uint16_t m = (uint16_t)atoi(hhmm + 3);
+  return h * 60 + m;
+}
+
+void Schedule::loadWindows(JsonArrayConst windows) {
+  _windows.clear();
+  _overridden = false;
+  for (JsonArrayConst pair : windows) {
+    if (pair.size() < 2) continue;
+    const char* on  = pair[0].as<const char*>();
+    const char* off = pair[1].as<const char*>();
+    if (!on || !off) continue;
+    _windows.push_back({parseMinutes(on), parseMinutes(off)});
+  }
+}
+
+bool Schedule::isActive(time_t now) const {
+  if (_overridden) return _overrideState;
+
+  struct tm t;
+#ifdef ARDUINO
+  localtime_r(&now, &t);
+#else
+  localtime_r(&now, &t);
+#endif
+  uint16_t cur = (uint16_t)(t.tm_hour * 60 + t.tm_min);
+
+  for (const auto& w : _windows) {
+    if (w.onMinutes <= w.offMinutes) {
+      // Normal window (e.g. 08:00–22:00)
+      if (cur >= w.onMinutes && cur < w.offMinutes) return true;
+    } else {
+      // Overnight window (e.g. 22:00–06:00)
+      if (cur >= w.onMinutes || cur < w.offMinutes) return true;
+    }
+  }
+  return false;
+}
+
+void Schedule::setOverride(bool state) {
+  _overridden    = true;
+  _overrideState = state;
+}

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -1,7 +1,10 @@
 #include <unity.h>
 #include <ArduinoJson.h>
+#include <cstdlib>
 #include "peripheral_manager.h"
+#include "schedule.h"
 #include "../../src/peripheral_manager.cpp"
+#include "../../src/schedule.cpp"
 
 // ── mock peripheral ──────────────────────────────────────────────────────────
 
@@ -127,17 +130,98 @@ void test_dispatch_command_routes_by_name(void) {
   TEST_ASSERT_EQUAL_STRING("", b.lastCmd.c_str());
 }
 
+// ── Schedule tests ───────────────────────────────────────────────────────────
+
+// All schedule tests run with TZ=UTC so localtime_r matches the UTC timestamps.
+// 2024-01-10 10:00:00 UTC
+static const time_t T_10_00 = 1704880800;
+// 2024-01-10 23:00:00 UTC
+static const time_t T_23_00 = 1704924000;
+// 2024-01-10 03:00:00 UTC
+static const time_t T_03_00 = 1704848400;
+
+static Schedule makeSchedule(const char* json) {
+  JsonDocument doc;
+  deserializeJson(doc, json);
+  Schedule s;
+  s.loadWindows(doc.as<JsonArrayConst>());
+  return s;
+}
+
+void test_schedule_no_windows_inactive() {
+  Schedule s;
+  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+}
+
+void test_schedule_normal_window_inside() {
+  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
+  TEST_ASSERT_TRUE(s.isActive(T_10_00));
+}
+
+void test_schedule_normal_window_outside() {
+  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
+  TEST_ASSERT_FALSE(s.isActive(T_23_00));
+}
+
+void test_schedule_overnight_after_on() {
+  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
+  TEST_ASSERT_TRUE(s.isActive(T_23_00));
+}
+
+void test_schedule_overnight_before_off() {
+  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
+  TEST_ASSERT_TRUE(s.isActive(T_03_00));
+}
+
+void test_schedule_overnight_outside() {
+  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
+  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+}
+
+void test_schedule_override_true() {
+  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
+  s.setOverride(true);
+  TEST_ASSERT_TRUE(s.isActive(T_23_00));
+}
+
+void test_schedule_override_false() {
+  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
+  s.setOverride(false);
+  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+}
+
+void test_schedule_load_clears_override() {
+  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
+  s.setOverride(false);
+  JsonDocument empty;
+  s.loadWindows(empty.as<JsonArrayConst>());
+  TEST_ASSERT_FALSE(s.hasOverride());
+}
+
 // ── entry point ──────────────────────────────────────────────────────────────
 
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
+  // Schedule tests use timestamps in UTC; force localtime_r to match.
+  setenv("TZ", "UTC0", 1);
+  tzset();
+
   UNITY_BEGIN();
   RUN_TEST(test_not_ticked_before_interval);
   RUN_TEST(test_ticked_after_interval);
   RUN_TEST(test_two_peripherals_tick_independently);
   RUN_TEST(test_tickAll_produces_flat_senml);
   RUN_TEST(test_dispatch_command_routes_by_name);
+  RUN_TEST(test_schedule_no_windows_inactive);
+  RUN_TEST(test_schedule_normal_window_inside);
+  RUN_TEST(test_schedule_normal_window_outside);
+  RUN_TEST(test_schedule_overnight_after_on);
+  RUN_TEST(test_schedule_overnight_before_off);
+  RUN_TEST(test_schedule_overnight_outside);
+  RUN_TEST(test_schedule_override_true);
+  RUN_TEST(test_schedule_override_false);
+  RUN_TEST(test_schedule_load_clears_override);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **RelayActuator**: active-low relay peripheral driven by a `Schedule` (time windows or manual override); reports state via SenML `vb`
- **Schedule helper**: supports normal and overnight windows (`["22:00","06:00"]`), plus immediate `setOverride()` that `loadWindows()` clears
- **FishHubMqttClient**: connects to HiveMQ Cloud over TLS (`mqtts://`), authenticates with device JWT as password, subscribes to `fishhub/<device_id>/commands/#`, and routes inbound commands to `PeripheralManager`
- **Command deduplication**: new `replayCommand()` virtual on `Peripheral` (`true` by default); non-replayable peripherals deduplicate against NVS-persisted last command ID — survives reboots and retained MQTT messages
- **`PeripheralManager::find()`**: added for command routing by peripheral name
- **Provisioning**: stores `device_id` from activation response in NVS; `main.cpp` checks `device_id` as part of provisioned state
- **Config**: `MQTT_URL` replaces separate `MQTT_HOST`/`MQTT_PORT`; `DEVICE_ID` added; `PubSubClient @ ^2.8` added to `platformio.ini`
- **Tests**: 9 new native unit tests for `Schedule` (normal/overnight windows, override, `loadWindows` clears override); all 14 native tests passing; `pio run` clean

## Test plan

- [x] `pio test -e native` — 14/14 tests pass
- [x] `pio run` — compiles cleanly for nodemcu-32s
- [ ] Flash to hardware, provision device, verify MQTT connects and relay responds to `{"id":"x","action":"set","state":true}`
- [ ] Verify schedule command: `{"id":"y","action":"schedule","windows":[["08:00","22:00"]]}`
- [ ] Verify duplicate command with same `id` is skipped after reboot (NVS dedup)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)