### PR TITLE
feat: switch MQTT auth to username/password credentials from server

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -6,12 +6,12 @@
 // Backend base URL (no trailing slash)
 #define SERVER_URL   "https://your-server.example.com"
 
-// MQTT broker — format: mqtts://host:port
-#define MQTT_URL     "mqtts://your-broker.hivemq.cloud:8883"
+// MQTT broker
+#define MQTT_HOST    "your-broker.hivemq.cloud"
+#define MQTT_PORT    8883
 
 // Device credentials — populated automatically by provisioning; set manually for dev
 #define DEVICE_ID    ""
-#define DEVICE_TOKEN ""
 
 // Sensor polling intervals (milliseconds)
 #define DS18B20_INTERVAL_MS 30000

--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -14,10 +14,13 @@ private:
   void connect();
   void onMessage(char* topic, byte* payload, unsigned int len);
 
-  WiFiClientSecure  _tlsClient;
-  PubSubClient      _client;
+  WiFiClientSecure   _tlsClient;
+  PubSubClient       _client;
   PeripheralManager* _manager = nullptr;
-  String            _deviceId;
-  String            _deviceJwt;
-  unsigned long     _lastConnectAttempt = 0;
+  String             _deviceId;
+  String             _mqttUsername;
+  String             _mqttPassword;
+  String             _mqttHost;
+  uint16_t           _mqttPort = 8883;
+  unsigned long      _lastConnectAttempt = 0;
 };

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -3,18 +3,23 @@
 #include "nvs_store.h"
 #include "config.h"
 
-static bool doPost(const String& payload, int& statusCode) {
-  String serverUrl   = nvsStore.get("server_url");
+static bool doPost(const String &payload, int &statusCode)
+{
+  String serverUrl = nvsStore.get("server_url");
   String deviceToken = nvsStore.get("device_jwt");
-  if (serverUrl.isEmpty())   serverUrl   = SERVER_URL;
-  if (deviceToken.isEmpty()) deviceToken = DEVICE_TOKEN;
+  if (serverUrl.isEmpty())
+    serverUrl = SERVER_URL;
+  if (deviceToken.isEmpty())
+    deviceToken = DEVICE_TOKEN;
   if (serverUrl.startsWith("http://") && !serverUrl.startsWith("http://192.") &&
-      !serverUrl.startsWith("http://10.") && !serverUrl.startsWith("http://172.")) {
+      !serverUrl.startsWith("http://10.") && !serverUrl.startsWith("http://172."))
+  {
     serverUrl.replace("http://", "https://");
   }
 
   HTTPClient http;
   http.begin(serverUrl + "/readings");
+  http.setTimeout(15000);
   http.addHeader("Content-Type", "application/json");
   http.addHeader("Authorization", "Bearer " + deviceToken);
 
@@ -24,23 +29,29 @@ static bool doPost(const String& payload, int& statusCode) {
 
   http.end();
 
-  if (statusCode > 0) {
+  if (statusCode > 0)
+  {
     Serial.printf("POST %d in %lums\n", statusCode, elapsed);
-  } else {
+  }
+  else
+  {
     Serial.printf("POST error: %s\n", HTTPClient::errorToString(statusCode).c_str());
   }
 
   return statusCode >= 200 && statusCode < 300;
 }
 
-bool postReading(const String& payload) {
+bool postReading(const String &payload)
+{
   int statusCode;
 
-  if (doPost(payload, statusCode)) {
+  if (doPost(payload, statusCode))
+  {
     return true;
   }
 
-  if (statusCode >= 500 || statusCode < 0) {
+  if (statusCode >= 500 || statusCode < 0)
+  {
     Serial.println("Retrying POST...");
     delay(1000);
     return doPost(payload, statusCode);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,9 +64,18 @@ void loop()
 {
   if (digitalRead(RESET_BUTTON_PIN) == LOW)
   {
+    Serial.println("Reset button pressed");
+    Serial.println("- 3s  => enter provisioning mode");
+    Serial.println("- 10s => clear data");
+
     unsigned long pressStart = millis();
     while (digitalRead(RESET_BUTTON_PIN) == LOW)
+    {
+      unsigned long heldUntilNow = millis() - pressStart;
+      Serial.printf("Held for %d ms\n", heldUntilNow);
       delay(50);
+    }
+
     unsigned long held = millis() - pressStart;
 
     if (held >= 10000)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,22 +16,14 @@
 PeripheralManager manager;
 FishHubMqttClient mqttClient;
 
-static void logNvsKey(const char* key) {
+static void logNvsKey(const char *key)
+{
   String val = nvsStore.get(key);
   Serial.printf("  NVS %-14s %s\n", key, val.isEmpty() ? "MISSING" : "present");
 }
 
-static bool buttonHeld(uint8_t pin, unsigned long durationMs) {
-  if (digitalRead(pin) == HIGH) return false;
-  unsigned long start = millis();
-  while (millis() - start < durationMs) {
-    delay(50);
-    if (digitalRead(pin) == HIGH) return false;
-  }
-  return true;
-}
-
-void setup() {
+void setup()
+{
   Serial.begin(115200);
   Serial.println("FishHub firmware booting...");
 
@@ -46,13 +38,14 @@ void setup() {
   logNvsKey("device_jwt");
 
   bool provisioned =
-    !nvsStore.get("wifi_ssid").isEmpty() &&
-    !nvsStore.get("wifi_pass").isEmpty() &&
-    !nvsStore.get("server_url").isEmpty() &&
-    !nvsStore.get("device_id").isEmpty() &&
-    !nvsStore.get("device_jwt").isEmpty();
+      !nvsStore.get("wifi_ssid").isEmpty() &&
+      !nvsStore.get("wifi_pass").isEmpty() &&
+      !nvsStore.get("server_url").isEmpty() &&
+      !nvsStore.get("device_id").isEmpty() &&
+      !nvsStore.get("device_jwt").isEmpty();
 
-  if (!provisioned) {
+  if (!provisioned)
+  {
     Serial.println("One or more NVS keys missing — entering provisioning mode");
     startProvisioning(); // never returns — device reboots after activation
   }
@@ -67,17 +60,34 @@ void setup() {
   mqttClient.begin(manager);
 }
 
-void loop() {
-  if (buttonHeld(RESET_BUTTON_PIN, 3000)) {
-    Serial.println("Button held — entering reconfiguration mode...");
-    startProvisioning(); // never returns
+void loop()
+{
+  if (digitalRead(RESET_BUTTON_PIN) == LOW)
+  {
+    unsigned long pressStart = millis();
+    while (digitalRead(RESET_BUTTON_PIN) == LOW)
+      delay(50);
+    unsigned long held = millis() - pressStart;
+
+    if (held >= 10000)
+    {
+      Serial.println("Button held 10s — clearing NVS and rebooting...");
+      nvsStore.clear();
+      ESP.restart();
+    }
+    else if (held >= 3000)
+    {
+      Serial.println("Button held 3s — entering reconfiguration mode...");
+      startProvisioning(); // never returns
+    }
   }
 
   mqttClient.loop();
 
   time_t now = time(nullptr);
   String payload = manager.tickAll(now, millis());
-  if (!payload.isEmpty()) {
+  if (!payload.isEmpty())
+  {
     postReading(payload);
   }
 }

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -5,40 +5,58 @@
 
 static const unsigned long RECONNECT_INTERVAL_MS = 5000;
 
-// Parse host and port out of "mqtts://host:port"
-static void parseMqttUrl(const String& url, String& host, uint16_t& port) {
-  int start = url.indexOf("://");
-  start = (start < 0) ? 0 : start + 3;
-  int colon = url.lastIndexOf(':');
-  if (colon > start) {
-    host = url.substring(start, colon);
-    port = (uint16_t)url.substring(colon + 1).toInt();
-  } else {
-    host = url.substring(start);
-    port = 8883;
-  }
-}
+// ISRG Root X1 — root CA for Let's Encrypt, used by HiveMQ Cloud
+static const char ISRG_ROOT_X1[] PROGMEM = R"EOF(
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----
+)EOF";
 
 void FishHubMqttClient::begin(PeripheralManager& manager) {
   _manager = &manager;
 
-  _deviceId  = nvsStore.get("device_id");
-  _deviceJwt = nvsStore.get("device_jwt");
-  if (_deviceId.isEmpty())  _deviceId  = DEVICE_ID;
-  if (_deviceJwt.isEmpty()) _deviceJwt = DEVICE_TOKEN;
+  _deviceId    = nvsStore.get("device_id");
+  if (_deviceId.isEmpty()) _deviceId = DEVICE_ID;
+  _mqttUsername = nvsStore.get("mqtt_username");
+  _mqttPassword = nvsStore.get("mqtt_password");
 
-  String mqttUrl = nvsStore.get("mqtt_url");
-  if (mqttUrl.isEmpty()) mqttUrl = MQTT_URL;
+  _mqttHost = nvsStore.get("mqtt_host");
+  if (_mqttHost.isEmpty()) _mqttHost = MQTT_HOST;
+  _mqttPort = MQTT_PORT;
 
-  String host;
-  uint16_t port;
-  parseMqttUrl(mqttUrl, host, port);
-
-  // PoC: skip certificate verification — see issue #27 for proper CA pinning
-  _tlsClient.setInsecure();
+  _tlsClient.setCACert(ISRG_ROOT_X1);
 
   _client.setClient(_tlsClient);
-  _client.setServer(host.c_str(), port);
+  _client.setBufferSize(1024);
+  _client.setServer(_mqttHost.c_str(), _mqttPort);
   _client.setCallback([this](char* topic, byte* payload, unsigned int len) {
     onMessage(topic, payload, len);
   });
@@ -58,17 +76,16 @@ void FishHubMqttClient::loop() {
 }
 
 void FishHubMqttClient::connect() {
-  if (_deviceId.isEmpty() || _deviceJwt.isEmpty()) {
-    Serial.println("MQTT: device_id or device_jwt missing — skipping connect");
+  if (_deviceId.isEmpty() || _mqttUsername.isEmpty() || _mqttPassword.isEmpty()) {
+    Serial.println("MQTT: device_id, mqtt_username, or mqtt_password missing — skipping connect");
     return;
   }
 
-  Serial.printf("MQTT: connecting as %s...\n", _deviceId.c_str());
-  // Authenticate with device JWT as password; broker verifies signature via JWKS
+  Serial.printf("MQTT: connecting as %s...\n", _mqttUsername.c_str());
   bool ok = _client.connect(
-    _deviceId.c_str(),  // client ID
-    _deviceId.c_str(),  // username (must match JWT sub for HiveMQ topic filter)
-    _deviceJwt.c_str()  // password — RS256 JWT verified by HiveMQ JWT IdP
+    _deviceId.c_str(),      // client ID
+    _mqttUsername.c_str(),  // username
+    _mqttPassword.c_str()   // password
   );
 
   if (!ok) {
@@ -101,7 +118,6 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
     return;
   }
 
-  // Find the peripheral to check its replay policy
   Peripheral* peripheral = _manager->find(peripheralName);
   if (!peripheral) {
     Serial.printf("MQTT: no peripheral named '%s'\n", peripheralName.c_str());
@@ -109,7 +125,6 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
   }
 
   if (!peripheral->replayCommand()) {
-    // Non-replayable: check last processed ID in NVS
     String nvsKey = String("cmd_") + peripheralName;
     String lastId = nvsStore.get(nvsKey.c_str());
     if (lastId == cmdId) {

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -366,22 +366,38 @@ ActivationError activateDevice(const String &provisionCode)
   // Parse response: { device_id, token }
   JsonDocument doc;
   DeserializationError jsonErr = deserializeJson(doc, resp);
-  String token    = jsonErr ? String() : doc["token"].as<String>();
-  String deviceId = jsonErr ? String() : doc["device_id"].as<String>();
-  Serial.printf("Activation: token length=%d  device_id=%s\n",
-                token.length(), deviceId.isEmpty() ? "(missing)" : deviceId.c_str());
+  String token        = jsonErr ? String() : doc["token"].as<String>();
+  String deviceId     = jsonErr ? String() : doc["device_id"].as<String>();
+  String mqttUsername = jsonErr ? String() : doc["mqtt_username"].as<String>();
+  String mqttPassword = jsonErr ? String() : doc["mqtt_password"].as<String>();
+  String mqttHost     = jsonErr ? String() : doc["mqtt_host"].as<String>();
+  Serial.printf("Activation: token length=%d  device_id=%s  mqtt_username=%s\n",
+                token.length(),
+                deviceId.isEmpty() ? "(missing)" : deviceId.c_str(),
+                mqttUsername.isEmpty() ? "(missing)" : mqttUsername.c_str());
   if (token.isEmpty())
   {
     Serial.println("Activation: server returned empty token — DEVICE_JWT_PRIVATE_KEY not configured on server");
     restartAP();
     return ActivationError::ServerError;
   }
+  if (mqttUsername.isEmpty() || mqttPassword.isEmpty())
+  {
+    Serial.println("Activation: server returned no MQTT credentials — HIVEMQ_API_BASE_URL not configured on server");
+    restartAP();
+    return ActivationError::ServerError;
+  }
 
   nvsStore.set("device_jwt", token);
-  if (!deviceId.isEmpty()) nvsStore.set("device_id", deviceId);
-  Serial.printf("Activation: device_jwt stored=%s  device_id stored=%s\n",
-                nvsStore.get("device_jwt").isEmpty() ? "FAILED" : "OK",
-                nvsStore.get("device_id").isEmpty() ? "FAILED" : "OK");
+  if (!deviceId.isEmpty())     nvsStore.set("device_id",      deviceId);
+  if (!mqttUsername.isEmpty()) nvsStore.set("mqtt_username",  mqttUsername);
+  if (!mqttPassword.isEmpty()) nvsStore.set("mqtt_password",  mqttPassword);
+  if (!mqttHost.isEmpty())     nvsStore.set("mqtt_host",      mqttHost);
+  Serial.printf("Activation: device_jwt=%s  device_id=%s  mqtt_username=%s  mqtt_host=%s\n",
+                nvsStore.get("device_jwt").isEmpty()    ? "FAILED" : "OK",
+                nvsStore.get("device_id").isEmpty()     ? "FAILED" : "OK",
+                nvsStore.get("mqtt_username").isEmpty() ? "FAILED" : "OK",
+                nvsStore.get("mqtt_host").isEmpty()     ? "FAILED" : "OK");
   Serial.println("Activation successful. Rebooting...");
   delay(1000);
   ESP.restart();


### PR DESCRIPTION
Replaces JWT-based MQTT authentication with per-device username/password credentials provisioned by the server at activation.

- Parse `mqtt_username`, `mqtt_password`, and `mqtt_host` from the activation response and persist to NVS
- Use those credentials in `FishHubMqttClient::connect()` instead of `device_jwt`
- Pin ISRG Root X1 CA for TLS verification (replaces `setInsecure()`)
- Replace `MQTT_URL` define with `MQTT_HOST` / `MQTT_PORT` in `config.h.example`
- Increase activation HTTP timeout to 15s to accommodate HiveMQ provisioning latency

Closes #34

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>