### PR TITLE
refactor: remove server_url from captive portal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Static helper `buttonHeld(pin, durationMs)` polls the pin every 50 ms and return
 ### `nvs_store.h` / `nvs_store.cpp`
 `NVSStore` wraps the Arduino `Preferences` library to provide named key-value storage backed by ESP32 NVS flash. A global `nvsStore` instance is defined in `nvs_store.cpp` and shared across all modules.
 
-Stored keys: `wifi_ssid`, `wifi_pass`, `server_url`, `device_token`.
+Stored keys: `wifi_ssid`, `wifi_pass`, `device_id`, `device_jwt`, `mqtt_username`, `mqtt_password`, `mqtt_host`.
 
 ### `provisioning.h` / `provisioning.cpp`
 Captive-portal provisioning and device activation.
@@ -42,10 +42,10 @@ Captive-portal provisioning and device activation.
 - `startProvisioning()` — starts a Wi-Fi AP (`"FishHub-Setup"`, mode `WIFI_AP_STA`) at `192.168.4.1`, serves an HTML form, and never returns. A FreeRTOS task on core 0 scans nearby networks (mutex-protected) to populate the SSID dropdown.
 
   Two modes are detected automatically at form-submit time:
-  - **Fresh provisioning** (`device_token` absent in NVS): saves credentials, calls `activateDevice()`, reboots on success, shows an error page on failure.
-  - **Reconfiguration** (`device_token` present in NVS): saves Wi-Fi credentials and server URL, reboots immediately — no server call, existing token is preserved.
+  - **Fresh provisioning** (`device_jwt` absent in NVS): saves Wi-Fi credentials, calls `activateDevice()`, reboots on success, shows an error page on failure.
+  - **Reconfiguration** (`device_jwt` present in NVS): saves Wi-Fi credentials only, reboots immediately — no server call, existing token and MQTT credentials are preserved.
 
-- `activateDevice(const String& provisionCode)` — connects to Wi-Fi, POSTs `{"code":"..."}` to `{server_url}/devices/activate`, parses the Bearer token from the response, stores it in NVS, and reboots.
+- `activateDevice(const String& provisionCode)` — connects to Wi-Fi, POSTs `{"code":"..."}` to `SERVER_URL/devices/activate` (from `config.h`), parses the JWT and MQTT credentials from the response, stores them in NVS, and reboots.
 
 - `enum class ActivationError { None, WifiFailed, InvalidCode, ServerError }` — result type returned by `activateDevice()`.
 
@@ -57,7 +57,7 @@ Captive-portal provisioning and device activation.
 - `buildSenMLPayload(float tempCelsius, time_t timestamp)` — serialises a single SenML record with ArduinoJson. Returns an Arduino `String`. See [wire-format.md](wire-format.md) for the schema.
 
 ### `http_client.h` / `http_client.cpp`
-- `postReading(const String& payload)` — reads `server_url` and `device_token` from NVS (falls back to `config.h`). Appends `"/readings"` to the server URL and normalises `http://` to `https://` for non-local IPs. POSTs the payload with `Authorization: Bearer <token>`. On a 5xx or network error, retries once after 1 s.
+- `postReading(const String& payload)` — uses `SERVER_URL` from `config.h` and reads `device_jwt` from NVS. Appends `"/readings"` to the server URL and normalises `http://` to `https://` for non-local IPs. POSTs the payload with `Authorization: Bearer <token>`. On a 5xx or network error, retries once after 1 s.
 
 ### `include/pins.h`
 - `ONE_WIRE_PIN 4` — GPIO pin for the DS18B20 OneWire data line.
@@ -70,7 +70,7 @@ setup()
   ├── Serial.begin(115200)
   ├── nvsStore.begin()
   ├── pinMode(RESET_BUTTON_PIN, INPUT_PULLUP)
-  ├── [check NVS for wifi_ssid, wifi_pass, server_url, device_token]
+  ├── [check NVS for wifi_ssid, wifi_pass, device_id, device_jwt]
   │     └── any missing → startProvisioning()  ← never returns
   ├── connectWifi()        — blocks until connected or halts
   ├── waitForNtp()         — blocks until UTC time is synced or halts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,19 +20,18 @@ Device credentials are stored in ESP32 NVS (non-volatile storage) and written vi
 4. Open `http://192.168.4.1` in a browser. The captive portal form shows:
    - **Wi-Fi network** — dropdown populated from a background scan, with a manual entry fallback
    - **Password** — Wi-Fi password (show/hide toggle)
-   - **Server URL** — base URL of the FishHub backend (e.g. `http://192.168.1.10:8080`)
-   - **Provisioning code** — one-time code from the web app (only shown on fresh provisioning)
+   - **Provisioning code** — one-time code from the web app
 5. Submit the form. The device:
    1. Connects to the specified Wi-Fi network.
-   2. POSTs `{"code":"<provisioning-code>"}` to `{server_url}/devices/activate`.
-   3. Parses the Bearer token from the response and stores all credentials in NVS.
+   2. POSTs `{"code":"<provisioning-code>"}` to `SERVER_URL/devices/activate` (the URL compiled into the firmware from `config.h`).
+   3. Parses the JWT and MQTT credentials from the response and stores them in NVS.
    4. Reboots into normal operation.
 
 If activation fails (wrong code, Wi-Fi unreachable, server error) the portal displays an error page. The device can be retried without reflashing.
 
-### Reconfiguration (update Wi-Fi or server URL)
+### Reconfiguration (update Wi-Fi credentials)
 
-Hold the **BOOT button** (GPIO 0) for **3 seconds** while the device is running. The device starts the AP in reconfiguration mode — the form appears without the provisioning code field. Submitting saves the new Wi-Fi credentials and server URL to NVS and reboots. The existing `device_token` is preserved; no server call is made.
+Hold the **BOOT button** (GPIO 0) for **3 seconds** while the device is running. The device starts the AP in reconfiguration mode — the form shows only the Wi-Fi fields (no provisioning code). Submitting saves the new Wi-Fi credentials to NVS and reboots. The existing `device_jwt` and MQTT credentials are preserved; no server call is made.
 
 ---
 
@@ -60,10 +59,12 @@ Then fill in the defines:
 |---|---|
 | `WIFI_SSID` | SSID of the Wi-Fi network the ESP32 will join |
 | `WIFI_PASSWORD` | Wi-Fi password |
-| `SERVER_URL` | Base URL of the FishHub backend. Use the local IP of the machine running the server — `localhost` won't resolve on device. `"/readings"` is appended automatically by `http_client`. |
-| `DEVICE_TOKEN` | 64-char hex Bearer token issued by the server |
+| `SERVER_URL` | Base URL of the FishHub backend (required at compile time — never entered at provisioning). Use the local IP of the machine running the server — `localhost` won't resolve on device. `"/readings"` is appended automatically by `http_client`. |
+| `MQTT_HOST` | HiveMQ broker hostname (used as fallback if NVS is empty) |
+| `MQTT_PORT` | HiveMQ broker port (default `8883`) |
+| `DEVICE_ID` | Device ID — leave empty; populated automatically by provisioning |
 
-`config.h` values are only read when the corresponding NVS key is empty. On a provisioned device the NVS values take precedence and `config.h` is ignored entirely.
+`SERVER_URL` is always read from `config.h` at compile time — it is never stored in NVS. `WIFI_SSID` and `WIFI_PASSWORD` are fallbacks used when NVS is empty; on a provisioned device the NVS values take precedence.
 
 ## `include/pins.h`
 

--- a/include/config.h.example
+++ b/include/config.h.example
@@ -3,7 +3,7 @@
 #define WIFI_SSID     "your-ssid"
 #define WIFI_PASSWORD "your-password"
 
-// Backend base URL (no trailing slash)
+// Backend base URL (no trailing slash) — set at compile time, not entered at provisioning
 #define SERVER_URL   "https://your-server.example.com"
 
 // MQTT broker

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -5,10 +5,8 @@
 
 static bool doPost(const String &payload, int &statusCode)
 {
-  String serverUrl = nvsStore.get("server_url");
+  String serverUrl = SERVER_URL;
   String deviceToken = nvsStore.get("device_jwt");
-  if (serverUrl.isEmpty())
-    serverUrl = SERVER_URL;
   if (deviceToken.isEmpty())
     deviceToken = DEVICE_TOKEN;
   if (serverUrl.startsWith("http://") && !serverUrl.startsWith("http://192.") &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,6 @@ void setup()
   Serial.println("NVS key status:");
   logNvsKey("wifi_ssid");
   logNvsKey("wifi_pass");
-  logNvsKey("server_url");
   logNvsKey("device_id");
   logNvsKey("device_jwt");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,6 @@ void setup()
   bool provisioned =
       !nvsStore.get("wifi_ssid").isEmpty() &&
       !nvsStore.get("wifi_pass").isEmpty() &&
-      !nvsStore.get("server_url").isEmpty() &&
       !nvsStore.get("device_id").isEmpty() &&
       !nvsStore.get("device_jwt").isEmpty();
 

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -1,5 +1,6 @@
 #include "provisioning.h"
 #include "nvs_store.h"
+#include "config.h"
 #include <WiFi.h>
 #include <WebServer.h>
 #include <HTTPClient.h>
@@ -65,7 +66,7 @@ static const char TOGGLE_SCRIPT[] =
 
 // reconfiguring = device already has a token; omit provisioning code field
 static String buildForm(const String &errorMsg, const String &prefillSsid,
-                        const String &prefillUrl, bool reconfiguring)
+                        bool reconfiguring)
 {
   String html = "<!DOCTYPE html><html lang='en'><head>"
                 "<meta charset='UTF-8'>"
@@ -133,14 +134,6 @@ static String buildForm(const String &errorMsg, const String &prefillSsid,
           "</div>"
           "</div>";
 
-  // Server URL
-  html += "<div class='field'>"
-          "<label for='server_url'>Server URL</label>"
-          "<input id='server_url' name='server_url' autocapitalize='none' autocorrect='off' "
-          "placeholder='http://192.168.1.10:8080' required value='" +
-          prefillUrl + "'>"
-                       "</div>";
-
   // Provisioning code — only shown on fresh provisioning
   if (!reconfiguring)
   {
@@ -198,8 +191,7 @@ static bool reconfiguring = false;
 
 static void handleRoot()
 {
-  String prefillUrl = reconfiguring ? nvsStore.get("server_url") : "";
-  server.send(200, "text/html", buildForm("", "", prefillUrl, reconfiguring));
+  server.send(200, "text/html", buildForm("", "", reconfiguring));
 }
 
 static void handleConfigure()
@@ -211,24 +203,20 @@ static void handleConfigure()
   ssid.trim();
 
   String password = server.arg("wifi_password");
-  String serverUrl = server.arg("server_url");
-  serverUrl.trim();
 
   if (reconfiguring)
   {
-    Serial.printf("Reconfigure: ssid=%s server_url=%s\n",
-                  ssid.c_str(), serverUrl.c_str());
+    Serial.printf("Reconfigure: ssid=%s\n", ssid.c_str());
 
-    if (ssid.isEmpty() || password.isEmpty() || serverUrl.isEmpty())
+    if (ssid.isEmpty() || password.isEmpty())
     {
       server.send(200, "text/html",
-                  buildForm("All fields are required.", ssid, serverUrl, true));
+                  buildForm("All fields are required.", ssid, true));
       return;
     }
 
     nvsStore.set("wifi_ssid", ssid);
     nvsStore.set("wifi_pass", password);
-    nvsStore.set("server_url", serverUrl);
 
     server.send(200, "text/html", buildConnecting());
     server.client().flush();
@@ -242,19 +230,17 @@ static void handleConfigure()
   String code = server.arg("provision_code");
   code.trim();
 
-  Serial.printf("Configure: ssid=%s server_url=%s code=%s\n",
-                ssid.c_str(), serverUrl.c_str(), code.c_str());
+  Serial.printf("Configure: ssid=%s code=%s\n", ssid.c_str(), code.c_str());
 
-  if (ssid.isEmpty() || password.isEmpty() || serverUrl.isEmpty() || code.isEmpty())
+  if (ssid.isEmpty() || password.isEmpty() || code.isEmpty())
   {
     server.send(200, "text/html",
-                buildForm("All fields are required.", ssid, serverUrl, false));
+                buildForm("All fields are required.", ssid, false));
     return;
   }
 
   nvsStore.set("wifi_ssid", ssid);
   nvsStore.set("wifi_pass", password);
-  nvsStore.set("server_url", serverUrl);
 
   // Send a "connecting" page immediately so the browser has a response
   // before we drop the AP to connect to the user's Wi-Fi network.
@@ -272,17 +258,17 @@ static void handleConfigure()
   case ActivationError::WifiFailed:
     server.send(200, "text/html",
                 buildForm("Could not connect to Wi-Fi. Check the network name and password.",
-                          ssid, serverUrl, false));
+                          ssid, false));
     break;
   case ActivationError::InvalidCode:
     server.send(200, "text/html",
                 buildForm("Invalid provisioning code. Generate a new one in the app.",
-                          ssid, serverUrl, false));
+                          ssid, false));
     break;
   case ActivationError::ServerError:
     server.send(200, "text/html",
-                buildForm("Could not reach the server. Check the Server URL.",
-                          ssid, serverUrl, false));
+                buildForm("Could not reach the server. Check the server configuration.",
+                          ssid, false));
     break;
   default:
     break;
@@ -301,7 +287,7 @@ ActivationError activateDevice(const String &provisionCode)
 {
   String ssid = nvsStore.get("wifi_ssid");
   String password = nvsStore.get("wifi_pass");
-  String serverUrl = nvsStore.get("server_url");
+  String serverUrl = SERVER_URL;
   // Normalize to HTTPS — Railway and most hosted servers require it
   if (serverUrl.startsWith("http://") && !serverUrl.startsWith("http://192.") &&
       !serverUrl.startsWith("http://10.") && !serverUrl.startsWith("http://172."))


### PR DESCRIPTION
## Summary

- Captive portal form now only asks for Wi-Fi SSID, password, and provisioning code — no Server URL field
- `activateDevice()` reads `SERVER_URL` from `config.h` at compile time instead of NVS
- `http_client.cpp` uses `SERVER_URL` directly; no NVS read or fallback
- `main.cpp` boot check no longer requires `server_url` in NVS
- `config.h.example` and both docs files updated to reflect the change

## Test plan

- [x] `pio run` compiles with zero warnings ✓
- [x] Fresh provisioning: form has no Server URL field; device activates using compiled-in URL
- [x] Reconfiguration (3s button hold): form shows only Wi-Fi fields

Closes #32