### PR TITLE
feat: send relay state on change or heartbeat

### DIFF
--- a/include/config.h.example
+++ b/include/config.h.example
@@ -15,3 +15,7 @@
 
 // Sensor polling intervals (milliseconds)
 #define DS18B20_INTERVAL_MS 30000
+
+// How often actuator state is written to InfluxDB even when unchanged (seconds).
+// Default is 300 (5 min). Override here to change it.
+// #define ACTUATOR_HEARTBEAT_S 300

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -13,13 +13,18 @@ void RelayActuator::begin() {
 
 bool RelayActuator::tick(time_t now) {
   bool desired = _schedule.isActive(now);
-  if (desired != _currentState) {
+  bool changed = desired != _currentState;
+  if (changed) {
     // Active-low: LOW energizes the relay (on), HIGH de-energizes (off)
     digitalWrite(_pin, desired ? LOW : HIGH);
     _currentState = desired;
     Serial.printf("Relay %s: %s\n", _name, desired ? "ON" : "OFF");
   }
-  return true;
+  if (changed || now - _lastSentAt >= ACTUATOR_HEARTBEAT_S) {
+    _lastSentAt = now;
+    return true;
+  }
+  return false;
 }
 
 void RelayActuator::appendSenML(JsonArray& records, time_t /*now*/) {

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -4,6 +4,10 @@
 #include "peripheral.h"
 #include "schedule.h"
 
+#ifndef ACTUATOR_HEARTBEAT_S
+#define ACTUATOR_HEARTBEAT_S 300
+#endif
+
 class RelayActuator : public Peripheral {
 public:
   RelayActuator(const char* name, uint8_t pin);
@@ -23,4 +27,5 @@ private:
   uint8_t     _pin;
   Schedule    _schedule;
   bool        _currentState = false;
+  time_t      _lastSentAt   = 0;
 };


### PR DESCRIPTION
## Summary

- `RelayActuator::tick()` previously always returned `true`, writing `light/state` to InfluxDB every second (~86,400 redundant points/day)
- Now returns `true` only on state change, or every `ACTUATOR_HEARTBEAT_S` seconds (default 300 — 5 min)
- The heartbeat ensures the dashboard always has a recent data point for last-known-state display after a page refresh
- `ACTUATOR_HEARTBEAT_S` is defined with `#ifndef` in `relay_actuator.h` and can be overridden in `config.h`

## Test plan

- [ ] `pio run` compiles with zero warnings ✓
- [ ] Serial output shows relay transitions only on actual state change
- [ ] InfluxDB receives at most one point per 5 minutes during stable state

Closes #37