### PR TITLE
docs: update docs to reflect current firmware architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,87 +4,157 @@
 
 ```
 fishhub-firmware/
-├── platformio.ini          # build environments (nodemcu-32s, native)
+├── platformio.ini              # build environments (nodemcu-32s, native)
 ├── include/
-│   ├── pins.h              # GPIO pin definitions (ONE_WIRE_PIN, RESET_BUTTON_PIN)
-│   ├── nvs_store.h         # NVSStore class — persistent key-value storage
-│   ├── provisioning.h      # startProvisioning(), activateDevice(), ActivationError
-│   ├── config.h            # credentials fallback for development (gitignored)
-│   └── config.h.example    # template for config.h
+│   ├── pins.h                  # GPIO pin definitions
+│   ├── nvs_store.h             # NVSStore class — persistent key-value storage
+│   ├── provisioning.h          # startProvisioning(), ActivationError
+│   ├── peripheral_manager.h    # PeripheralManager + Peripheral interface
+│   ├── config.h                # credentials fallback for development (gitignored)
+│   └── config.h.example        # template for config.h
 ├── src/
-│   ├── main.cpp            # entry point: setup() + loop()
-│   ├── nvs_store.cpp       # NVSStore implementation; global nvsStore instance
-│   ├── provisioning.cpp    # captive portal AP, Wi-Fi scan, device activation
-│   ├── wifi_ntp.h/.cpp     # Wi-Fi connection + NTP time sync
-│   ├── senml.h/.cpp        # SenML JSON payload builder
-│   └── http_client.h/.cpp  # HTTP POST with retry logic
-├── lib/                    # (reserved for local libraries)
+│   ├── main.cpp                # entry point: setup() + loop(), state dispatch
+│   ├── nvs_store.cpp           # NVSStore implementation; global nvsStore instance
+│   ├── provisioning.cpp        # captive portal AP, device activation, status polling
+│   ├── wifi_ntp.h/.cpp         # Wi-Fi connection + NTP time sync
+│   ├── http_client.h/.cpp      # HTTP POST for sensor readings with retry
+│   ├── mqtt_client.h/.cpp      # FishHubMqttClient — TLS MQTT, command dispatch
+│   ├── peripheral_manager.cpp  # PeripheralManager implementation
+│   ├── schedule.h/.cpp         # Schedule — time-window + override state for actuators
+│   └── peripherals/
+│       ├── ds18b20_sensor.h/.cpp   # DS18B20Sensor — temperature reading via OneWire
+│       └── relay_actuator.h/.cpp   # RelayActuator — GPIO relay driven by Schedule
+├── lib/                        # (reserved for local libraries)
 └── test/
     └── test_senml/
-        └── test_main.cpp   # native unit tests for SenML builder
+        └── test_main.cpp       # native unit tests for SenML builder
 ```
 
 ## Module responsibilities
 
 ### `main.cpp`
-Entry point. `setup()` initialises NVS, configures the reset button pin, checks that all required credentials are present in NVS (calling `startProvisioning()` if any are missing), then connects Wi-Fi, syncs NTP, and initialises the DS18B20 sensor. `loop()` checks the reset button first, then reads temperature, builds the SenML payload, and POSTs it — then calls `delay(5000)`.
+Entry point. Delegates all work to named helpers — no business logic is written inline:
 
-Static helper `buttonHeld(pin, durationMs)` polls the pin every 50 ms and returns `true` if it is held LOW for the full duration.
+- `boot()` — initialises Serial, NVS, and the reset button pin; logs NVS key status.
+- `provisioningMode()` — calls `startProvisioning()`, which never returns.
+- `connectToWifi()` — calls `connectWifi()` then `waitForNtp()`.
+- `normalOperation()` — registers peripherals, calls `manager.beginAll()` and `mqttClient.begin()`.
+- `handleButton()` — polls the reset button: 3 s hold → `provisioningMode()`; 10 s hold → `nvsStore.clear()` + reboot.
+- `sensorTick()` — calls `mqttClient.loop()`, runs `manager.tickAll()`, and POSTs any resulting SenML payload.
+
+`setup()` drives the linear boot sequence; `loop()` runs `handleButton()` then `sensorTick()` on every iteration.
 
 ### `nvs_store.h` / `nvs_store.cpp`
 `NVSStore` wraps the Arduino `Preferences` library to provide named key-value storage backed by ESP32 NVS flash. A global `nvsStore` instance is defined in `nvs_store.cpp` and shared across all modules.
 
-Stored keys: `wifi_ssid`, `wifi_pass`, `device_id`, `device_jwt`, `mqtt_username`, `mqtt_password`, `mqtt_host`.
+`isProvisioned()` returns `true` only when the `provisioned` flag is `"1"` **and** all required keys (`wifi_ssid`, `wifi_pass`, `device_id`, `device_jwt`, `mqtt_username`, `mqtt_password`, `mqtt_host`) are present. This implements atomic provisioning: if power is lost mid-write the flag will be absent and the device re-enters AP mode.
+
+`clear()` removes all keys including `provisioned`.
 
 ### `provisioning.h` / `provisioning.cpp`
 Captive-portal provisioning and device activation.
 
 - `startProvisioning()` — starts a Wi-Fi AP (`"FishHub-Setup"`, mode `WIFI_AP_STA`) at `192.168.4.1`, serves an HTML form, and never returns. A FreeRTOS task on core 0 scans nearby networks (mutex-protected) to populate the SSID dropdown.
 
-  Two modes are detected automatically at form-submit time:
-  - **Fresh provisioning** (`device_jwt` absent in NVS): saves Wi-Fi credentials, calls `activateDevice()`, reboots on success, shows an error page on failure.
-  - **Reconfiguration** (`device_jwt` present in NVS): saves Wi-Fi credentials only, reboots immediately — no server call, existing token and MQTT credentials are preserved.
+  Two modes are detected at form-submit time based on whether `device_jwt` is present in NVS:
 
-- `activateDevice(const String& provisionCode)` — connects to Wi-Fi, POSTs `{"code":"..."}` to `SERVER_URL/devices/activate` (from `config.h`), parses the JWT and MQTT credentials from the response, stores them in NVS, and reboots.
+  - **Fresh provisioning** (`device_jwt` absent): saves Wi-Fi credentials, calls `postActivate()`, polls `pollMqttCredentials()`, then writes all NVS keys atomically (setting `provisioned = "1"` last) and reboots.
+  - **Reconfiguration** (`device_jwt` present): writes new Wi-Fi credentials to temporary NVS keys (`wifi_ssid_new`, `wifi_pass_new`), attempts connection, promotes them to real keys and reboots on success, or deletes them and shows an error on failure — existing MQTT credentials are never touched.
 
-- `enum class ActivationError { None, WifiFailed, InvalidCode, ServerError }` — result type returned by `activateDevice()`.
+- `postActivate(code, serverUrl)` — POSTs `{"code":"..."}` to `SERVER_URL/devices/activate`, returns `{token, deviceId}` on 202 or an `ActivationError`.
+
+- `pollMqttCredentials(deviceId, jwt, serverUrl, out)` — polls `GET /devices/{id}/status` every 2 s for up to 60 s until `status == "ready"`, then fills `out` with `mqtt_username`, `mqtt_password`, `mqtt_host`. Returns `ActivationError::Timeout` if the deadline passes.
+
+- `enum class ActivationError { None, WifiFailed, InvalidCode, ServerError, Timeout }`
 
 ### `wifi_ntp.h` / `wifi_ntp.cpp`
 - `connectWifi()` — reads `wifi_ssid` / `wifi_pass` from NVS (falls back to `config.h` defines). Attempts up to 3 connections (10 s timeout each). Halts on total failure.
 - `waitForNtp()` — calls `configTime(0, 0, "pool.ntp.org")` and blocks until `getLocalTime()` succeeds (10 s timeout). Halts on failure.
 
-### `senml.h` / `senml.cpp`
-- `buildSenMLPayload(float tempCelsius, time_t timestamp)` — serialises a single SenML record with ArduinoJson. Returns an Arduino `String`. See [wire-format.md](wire-format.md) for the schema.
-
 ### `http_client.h` / `http_client.cpp`
-- `postReading(const String& payload)` — uses `SERVER_URL` from `config.h` and reads `device_jwt` from NVS. Appends `"/readings"` to the server URL and normalises `http://` to `https://` for non-local IPs. POSTs the payload with `Authorization: Bearer <token>`. On a 5xx or network error, retries once after 1 s.
+- `postReading(const String& payload)` — reads `device_jwt` from NVS, POSTs the SenML payload to `SERVER_URL/readings` with `Authorization: Bearer <token>`. Normalises `http://` to `https://` for non-local IPs. On a 5xx or network error, retries once after 1 s.
+
+### `mqtt_client.h` / `mqtt_client.cpp`
+`FishHubMqttClient` manages the TLS MQTT connection to HiveMQ Cloud and dispatches inbound commands to `PeripheralManager`.
+
+- `begin(manager)` — reads credentials from NVS (`device_id`, `mqtt_username`, `mqtt_password`, `mqtt_host`; falls back to `config.h` defines for host/port), sets up the TLS root CA (ISRG Root X1), connects, and subscribes to `fishhub/<device_id>/commands/#`.
+- `loop()` — calls `_client.loop()`; reconnects if disconnected (5 s cooldown).
+- On each inbound message, extracts the peripheral name from the last topic segment and calls `_manager->dispatchCommand()`. One-shot peripherals (`replayCommand() == false`) are deduplicated by persisting the last processed command ID in NVS (`cmd_<name>`); idempotent peripherals (schedules) always re-apply.
+
+### `peripheral_manager.h` / `peripheral_manager.cpp`
+`PeripheralManager` owns a list of `Peripheral*` entries and drives them uniformly. See [peripherals.md](peripherals.md) for the full interface and how to add a new peripheral.
+
+- `add(p)` — registers a peripheral.
+- `beginAll()` — calls `begin()` on every peripheral.
+- `tickAll(now, nowMs)` — calls each peripheral's `tick()` when its `intervalMs()` has elapsed; if any return `true`, collects `appendSenML()` output and returns a complete SenML JSON string (with base record). Returns `""` if nothing produced output.
+- `dispatchCommand(name, cmd)` — routes a parsed JSON command to the peripheral matching `name()`.
+- `find(name)` — returns the matching peripheral or `nullptr`.
+
+### `schedule.h` / `schedule.cpp`
+`Schedule` implements time-window–based on/off logic for actuators.
+
+- `loadWindows(windows)` — parses an array of `["HH:MM","HH:MM"]` pairs. Handles overnight windows (e.g. 22:00–06:00). Clears any active override.
+- `isActive(now)` — returns `true` if `now` falls within any window (or if an override is set).
+- `setOverride(state)` — forces a fixed state until the next `loadWindows()` call.
+
+### `peripherals/ds18b20_sensor.h/.cpp`
+`DS18B20Sensor` reads water temperature from a DS18B20 probe on a OneWire bus.
+
+- `name()` returns `"temperature"`.
+- `tick()` reads the sensor; `appendSenML()` emits a record with field `"v"` (Celsius).
+- `intervalMs()` defaults to `DS18B20_INTERVAL_MS` (override via `platformio.ini` build flag; default 30 000 ms).
+
+### `peripherals/relay_actuator.h/.cpp`
+`RelayActuator` drives a GPIO relay using a `Schedule`.
+
+- `name()` returns the name passed at construction (e.g. `"light"`).
+- `applyCommand(cmd)` — parses `windows` (schedule) or `state` (immediate override) from the JSON command and updates the `Schedule`.
+- `tick()` evaluates the schedule every second and sets the GPIO accordingly. Emits a heartbeat SenML record every `ACTUATOR_HEARTBEAT_S` seconds (default 300 s) even when the state is unchanged, so the server always has a recent reading.
+- `replayCommand()` returns `true` — retained MQTT messages are re-applied on reboot, restoring schedule state without a round-trip to the server.
 
 ### `include/pins.h`
 - `ONE_WIRE_PIN 4` — GPIO pin for the DS18B20 OneWire data line.
-- `RESET_BUTTON_PIN 0` — GPIO 0 (BOOT button, active LOW). Holding it for 3 seconds during normal operation triggers reconfiguration mode.
+- `RESET_BUTTON_PIN 0` — GPIO 0 (BOOT button, active LOW). Holding for 3 s enters reconfiguration mode; 10 s clears all NVS data.
+- `RELAY_LIGHT_PIN` — GPIO pin for the light relay (define in `pins.h`).
 
 ## Boot flow
 
 ```
 setup()
-  ├── Serial.begin(115200)
-  ├── nvsStore.begin()
-  ├── pinMode(RESET_BUTTON_PIN, INPUT_PULLUP)
-  ├── [check NVS for wifi_ssid, wifi_pass, device_id, device_jwt]
-  │     └── any missing → startProvisioning()  ← never returns
-  ├── connectWifi()        — blocks until connected or halts
-  ├── waitForNtp()         — blocks until UTC time is synced or halts
-  └── sensors.begin()      — initialises DS18B20 on OneWire bus
+  ├── boot()
+  │     ├── Serial.begin(115200)
+  │     ├── nvsStore.begin()
+  │     └── pinMode(RESET_BUTTON_PIN, INPUT_PULLUP)
+  ├── nvsStore.isProvisioned() == false → provisioningMode()  ← never returns
+  ├── connectToWifi()
+  │     ├── connectWifi()    — blocks until connected or halts
+  │     └── waitForNtp()     — blocks until UTC time synced or halts
+  └── normalOperation()
+        ├── manager.add(new DS18B20Sensor(...))
+        ├── manager.add(new RelayActuator("light", ...))
+        ├── manager.beginAll()
+        └── mqttClient.begin(manager)
 
-loop()  (runs repeatedly, no deep sleep in current implementation)
-  ├── [buttonHeld(RESET_BUTTON_PIN, 3000) → startProvisioning() if held]
-  ├── readTemperatureCelsius()
-  ├── buildSenMLPayload(temp, time(nullptr)) → String payload
-  ├── postReading(payload)
-  └── delay(5000)          — 5-second pause before next reading
+loop()
+  ├── handleButton()   — 3s → provisioningMode(); 10s → clear + reboot
+  └── sensorTick()
+        ├── mqttClient.loop()           — keep MQTT alive, dispatch inbound commands
+        ├── manager.tickAll(now, nowMs) — tick each peripheral on its interval
+        └── postReading(payload)        — POST SenML to server if any data produced
 ```
 
-> **Note:** Deep sleep is not yet implemented — the device stays awake and loops every 5 seconds (see GitHub issue #6).
+## Command flow (MQTT → peripheral)
+
+```
+HiveMQ Cloud
+  └── topic: fishhub/<device_id>/commands/<peripheral_name>
+        └── FishHubMqttClient::onMessage()
+              ├── parse JSON
+              ├── deduplicate (one-shot peripherals only, via NVS)
+              └── PeripheralManager::dispatchCommand(name, cmd)
+                    └── peripheral->applyCommand(cmd)
+                          └── (RelayActuator) Schedule::loadWindows() or setOverride()
+```
 
 ## PlatformIO environments
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,15 +23,38 @@ Device credentials are stored in ESP32 NVS (non-volatile storage) and written vi
    - **Provisioning code** — one-time code from the web app
 5. Submit the form. The device:
    1. Connects to the specified Wi-Fi network.
-   2. POSTs `{"code":"<provisioning-code>"}` to `SERVER_URL/devices/activate` (the URL compiled into the firmware from `config.h`).
-   3. Parses the JWT and MQTT credentials from the response and stores them in NVS.
-   4. Reboots into normal operation.
+   2. POSTs `{"code":"<provisioning-code>"}` to `SERVER_URL/devices/activate`.
+   3. Receives `202` with `{token, device_id}`.
+   4. Polls `GET /devices/{id}/status` every 2 s (up to 60 s) until the server responds `"ready"` with MQTT credentials.
+   5. Writes all credentials to NVS atomically — the `provisioned` flag is set last.
+   6. Reboots into normal operation.
 
-If activation fails (wrong code, Wi-Fi unreachable, server error) the portal displays an error page. The device can be retried without reflashing.
+If activation fails (wrong code, Wi-Fi unreachable, server error, or 60 s poll timeout) the portal displays an error. The device can be retried without reflashing.
+
+### NVS keys written during provisioning
+
+| Key | Description |
+|---|---|
+| `wifi_ssid` | Wi-Fi network name |
+| `wifi_pass` | Wi-Fi password |
+| `device_id` | UUID assigned by the server |
+| `device_jwt` | Bearer token for authenticating to the server |
+| `mqtt_username` | HiveMQ Cloud username |
+| `mqtt_password` | HiveMQ Cloud password |
+| `mqtt_host` | HiveMQ Cloud hostname |
+| `provisioned` | Atomicity flag — written `"1"` last; absent means provisioning was interrupted |
+
+The `provisioned` flag makes writes atomic: if power is lost between writing individual keys and setting the flag, `isProvisioned()` returns `false` and the device re-enters AP mode on the next boot so the user can try again.
 
 ### Reconfiguration (update Wi-Fi credentials)
 
-Hold the **BOOT button** (GPIO 0) for **3 seconds** while the device is running. The device starts the AP in reconfiguration mode — the form shows only the Wi-Fi fields (no provisioning code). Submitting saves the new Wi-Fi credentials to NVS and reboots. The existing `device_jwt` and MQTT credentials are preserved; no server call is made.
+Hold the **BOOT button** (GPIO 0) for **3 seconds** while the device is running. The device starts the AP in reconfiguration mode — the form shows only the Wi-Fi fields (no provisioning code).
+
+The new credentials are written to temporary NVS keys (`wifi_ssid_new`, `wifi_pass_new`) first. The device attempts to connect; if it succeeds the real keys are updated and the device reboots. If it fails the temporary keys are deleted and an error is shown — existing credentials are never modified. The existing `device_jwt` and MQTT credentials are always preserved; no server call is made.
+
+### Factory reset (clear all data)
+
+Hold the **BOOT button** for **10 seconds**. This clears all NVS keys (including `provisioned`) and reboots. The device starts fresh provisioning mode.
 
 ---
 
@@ -52,19 +75,22 @@ Then fill in the defines:
 #define WIFI_PASSWORD "your-password"
 
 #define SERVER_URL   "http://192.168.x.x:8080"
-#define DEVICE_TOKEN "your-64-char-hex-token"
+
+#define MQTT_HOST    "your-cluster.hivemq.cloud"
+#define MQTT_PORT    8883
+#define DEVICE_ID    ""   // leave empty — populated by provisioning
 ```
 
 | Define | Description |
 |---|---|
-| `WIFI_SSID` | SSID of the Wi-Fi network the ESP32 will join |
-| `WIFI_PASSWORD` | Wi-Fi password |
-| `SERVER_URL` | Base URL of the FishHub backend (required at compile time — never entered at provisioning). Use the local IP of the machine running the server — `localhost` won't resolve on device. `"/readings"` is appended automatically by `http_client`. |
-| `MQTT_HOST` | HiveMQ broker hostname (used as fallback if NVS is empty) |
-| `MQTT_PORT` | HiveMQ broker port (default `8883`) |
-| `DEVICE_ID` | Device ID — leave empty; populated automatically by provisioning |
+| `WIFI_SSID` | SSID of the Wi-Fi network the ESP32 will join (NVS takes precedence on provisioned devices) |
+| `WIFI_PASSWORD` | Wi-Fi password (NVS takes precedence) |
+| `SERVER_URL` | Base URL of the FishHub backend — compiled in at build time, never stored in NVS. Use the local IP; `localhost` won't resolve on device. `"/readings"` and `"/devices/..."` paths are appended by the firmware. |
+| `MQTT_HOST` | HiveMQ Cloud broker hostname (NVS takes precedence on provisioned devices) |
+| `MQTT_PORT` | HiveMQ Cloud broker port (default `8883`) |
+| `DEVICE_ID` | Leave empty — populated automatically by provisioning |
 
-`SERVER_URL` is always read from `config.h` at compile time — it is never stored in NVS. `WIFI_SSID` and `WIFI_PASSWORD` are fallbacks used when NVS is empty; on a provisioned device the NVS values take precedence.
+`SERVER_URL` is always read from `config.h` at compile time. `WIFI_SSID`, `WIFI_PASSWORD`, and `MQTT_HOST` are fallbacks used only when the corresponding NVS keys are empty.
 
 ## `include/pins.h`
 
@@ -72,7 +98,8 @@ Pin assignments are in `include/pins.h`:
 
 ```cpp
 #define ONE_WIRE_PIN      4   // DS18B20 data line
-#define RESET_BUTTON_PIN  0   // BOOT button (active LOW) — hold 3 s to reconfigure
+#define RESET_BUTTON_PIN  0   // BOOT button (active LOW) — hold 3s to reconfigure, 10s to factory reset
+#define RELAY_LIGHT_PIN   X   // GPIO for the light relay — set to your wiring
 ```
 
-GPIO 4 is the data line for the DS18B20 OneWire bus. GPIO 0 is the onboard BOOT button; holding it LOW for 3 seconds during normal operation triggers reconfiguration mode. Change `ONE_WIRE_PIN` if you wire the sensor to a different pin.
+GPIO 4 is the data line for the DS18B20 OneWire bus. GPIO 0 is the onboard BOOT button. Change `ONE_WIRE_PIN` or `RELAY_LIGHT_PIN` if you wire the hardware to different pins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,14 @@
 # fishhub-firmware — Documentation Index
 
-ESP32 Arduino firmware for FishHub aquarium monitoring. On first boot (or after a factory reset) the device starts a captive-portal Wi-Fi AP for provisioning. Once provisioned, each boot cycle reads water temperature from a DS18B20 probe, formats a SenML JSON payload, POSTs it to the FishHub backend, and loops.
+ESP32 Arduino firmware for FishHub aquarium monitoring. On first boot (or after a factory reset) the device starts a captive-portal Wi-Fi AP for provisioning. Once provisioned, the device reads sensor data, publishes it to the FishHub backend, and responds to MQTT commands from the server.
 
 ## Contents
 
 | Document | What it covers |
 |---|---|
-| [architecture.md](architecture.md) | Source layout, module responsibilities, boot flow |
-| [configuration.md](configuration.md) | `config.h` required defines, device provisioning |
+| [architecture.md](architecture.md) | Source layout, module responsibilities, boot flow, command flow |
+| [configuration.md](configuration.md) | `config.h` required defines, device provisioning, NVS keys |
+| [peripherals.md](peripherals.md) | `Peripheral` interface, `PeripheralManager`, concrete implementations, adding new peripherals |
 | [wire-format.md](wire-format.md) | SenML JSON structure, example payload, field semantics |
 | [development.md](development.md) | Build, flash, Serial monitor, unit tests |
 
@@ -19,8 +20,8 @@ pio run --target upload
 
 # 2. On first boot the device starts AP "FishHub-Setup"
 #    Connect to it from your phone or laptop, then open 192.168.4.1
-#    Fill in Wi-Fi credentials, server URL, and the provisioning code
-#    from the FishHub web app. The device reboots into normal operation.
+#    Fill in Wi-Fi credentials and the provisioning code from the FishHub web app.
+#    The device reboots into normal operation.
 
 # 3. Monitor Serial output
 pio device monitor
@@ -38,8 +39,12 @@ pio device monitor
 | Temperature sensor | DS18B20 via OneWire / DallasTemperature |
 | JSON serialization | ArduinoJson v7 |
 | HTTP client | ESP32 built-in HTTPClient |
+| MQTT client | PubSubClient over TLS (HiveMQ Cloud, port 8883) |
 | Wire format | SenML JSON (RFC 8428) |
-| Auth | Bearer token stored in NVS (provisioned via captive portal) |
+| Auth | Bearer JWT stored in NVS (provisioned via captive portal) |
+| MQTT auth | Username / password stored in NVS (provisioned via server at activation) |
 | Persistent storage | ESP32 NVS via Arduino `Preferences` |
 | Captive portal | Arduino `WebServer` (ESP32 built-in) |
+| Peripheral abstraction | `Peripheral` interface + `PeripheralManager` |
+| Actuator scheduling | `Schedule` class — time windows + override state |
 | Background tasks | FreeRTOS tasks (Wi-Fi scan during provisioning) |

--- a/docs/peripherals.md
+++ b/docs/peripherals.md
@@ -1,0 +1,156 @@
+# Peripherals
+
+## `Peripheral` interface (`include/peripheral.h`)
+
+Every sensor and actuator in FishHub implements the `Peripheral` interface. `PeripheralManager` drives all registered peripherals through this contract uniformly.
+
+```cpp
+class Peripheral {
+public:
+  virtual void        begin() = 0;
+  virtual uint32_t    intervalMs() const = 0;
+  virtual bool        tick(time_t now) = 0;
+  virtual void        appendSenML(JsonArray& records, time_t now) = 0;
+  virtual void        applyCommand(JsonObjectConst cmd) {}
+  virtual bool        replayCommand() const { return true; }
+  virtual const char* name() const = 0;
+};
+```
+
+| Method | Called by | Contract |
+|---|---|---|
+| `begin()` | `PeripheralManager::beginAll()` once at startup | Initialise hardware (GPIO, bus, etc.) |
+| `intervalMs()` | `PeripheralManager::tickAll()` | Minimum milliseconds between `tick()` calls |
+| `tick(now)` | `PeripheralManager::tickAll()` | Sample or evaluate state; return `true` if there is new data to publish |
+| `appendSenML(records, now)` | `PeripheralManager::tickAll()` | Append one or more SenML sibling records to the top-level array. Only called when `tick()` returned `true`. |
+| `applyCommand(cmd)` | `PeripheralManager::dispatchCommand()` | Handle an inbound MQTT command (parsed JSON object). Default no-op — sensors can leave this unimplemented. |
+| `replayCommand()` | `FishHubMqttClient::onMessage()` | Return `true` if retained/re-delivered MQTT commands should always be re-applied (idempotent peripherals, e.g. schedule-driven actuators). Return `false` for one-shot operations (e.g. a feeder) — the MQTT client will deduplicate by persisting the last processed command ID in NVS. |
+| `name()` | MQTT routing, SenML field prefix | Unique identifier for this peripheral. Used as the last segment of the MQTT command topic (`fishhub/<device_id>/commands/<name>`) and as the SenML field name prefix. |
+
+---
+
+## `PeripheralManager` (`include/peripheral_manager.h`)
+
+Owns a list of `Peripheral*` entries and drives them uniformly.
+
+```cpp
+class PeripheralManager {
+public:
+  void      add(Peripheral* p);
+  void      beginAll();
+  String    tickAll(time_t now, uint32_t nowMs);
+  void      dispatchCommand(const String& name, JsonObjectConst cmd);
+  Peripheral* find(const String& name);
+};
+```
+
+- `add(p)` — registers a peripheral. Ownership remains with the caller.
+- `beginAll()` — calls `begin()` on every registered peripheral.
+- `tickAll(now, nowMs)` — for each peripheral, calls `tick()` if `nowMs - lastTickedAt >= intervalMs()`. If any `tick()` returns `true`, calls `appendSenML()` and collects the records into a complete SenML JSON string (with base record `bn` and `bt`). Returns `""` if nothing produced output.
+- `dispatchCommand(name, cmd)` — finds the peripheral with `name()` matching `name` and calls `applyCommand(cmd)`.
+- `find(name)` — returns the matching peripheral or `nullptr`.
+
+---
+
+## Concrete implementations
+
+### `DS18B20Sensor` (`src/peripherals/ds18b20_sensor.h/.cpp`)
+
+Reads water temperature from a DS18B20 probe via OneWire/DallasTemperature.
+
+| Property | Value |
+|---|---|
+| `name()` | `"temperature"` |
+| `intervalMs()` | `DS18B20_INTERVAL_MS` build flag (default: `30000` ms) |
+| `replayCommand()` | `true` (default — sensors ignore commands) |
+
+`tick()` triggers a synchronous temperature conversion. `appendSenML()` emits:
+
+```json
+{"n":"temperature","v":24.5,"u":"Cel"}
+```
+
+Override the interval by setting `DS18B20_INTERVAL_MS` in `platformio.ini`:
+
+```ini
+[env:nodemcu-32s]
+build_flags = -DDS18B20_INTERVAL_MS=60000
+```
+
+---
+
+### `RelayActuator` (`src/peripherals/relay_actuator.h/.cpp`)
+
+Drives a GPIO relay using a `Schedule`. Supports both time-window scheduling and immediate state overrides via MQTT commands.
+
+| Property | Value |
+|---|---|
+| `name()` | Set at construction (e.g. `"light"`) |
+| `intervalMs()` | `1000` ms — evaluates the schedule every second |
+| `replayCommand()` | `true` — retained MQTT messages re-apply the schedule on reboot |
+
+**`applyCommand(cmd)` accepts two command shapes:**
+
+Schedule (time windows):
+```json
+{
+  "id": "cmd-uuid",
+  "windows": [["08:00","22:00"]]
+}
+```
+
+Immediate override:
+```json
+{
+  "id": "cmd-uuid",
+  "state": true
+}
+```
+
+`tick()` evaluates the schedule and sets the GPIO pin. It emits a heartbeat SenML record every `ACTUATOR_HEARTBEAT_S` seconds (default 300 s), even when the state hasn't changed, so the server always has a recent reading:
+
+```json
+{"n":"light","vb":true}
+```
+
+Override the heartbeat interval via build flag:
+```ini
+build_flags = -DACTUATOR_HEARTBEAT_S=60
+```
+
+---
+
+## `Schedule` (`src/schedule.h/.cpp`)
+
+Time-window–based on/off logic used by `RelayActuator`.
+
+- `loadWindows(windows)` — parses a JSON array of `["HH:MM","HH:MM"]` pairs. Clears any active override. Handles overnight windows (e.g. `["22:00","06:00"]`).
+- `isActive(now)` — returns `true` if `now` falls within any loaded window, or if an override is set.
+- `setOverride(state)` — forces a fixed `state` regardless of windows until the next `loadWindows()` call.
+
+---
+
+## `FishHubMqttClient` (`src/mqtt_client.h/.cpp`)
+
+Manages the TLS MQTT connection and routes inbound commands to `PeripheralManager`.
+
+- Connects to HiveMQ Cloud on port 8883 using the ISRG Root X1 CA.
+- Subscribes to `fishhub/<device_id>/commands/#`.
+- On each message, extracts the peripheral name from the last topic segment and calls `PeripheralManager::dispatchCommand()`.
+- For peripherals with `replayCommand() == false`, persists the last processed command ID in NVS under `cmd_<name>` and skips duplicates.
+- Reconnects automatically with a 5 s cooldown when the connection drops.
+
+---
+
+## Adding a new peripheral
+
+1. Create `src/peripherals/my_peripheral.h` and `my_peripheral.cpp` implementing `Peripheral`.
+2. Set `name()` to a unique lowercase string — this becomes the MQTT topic segment and the SenML field prefix.
+3. Implement `begin()`, `intervalMs()`, `tick()`, and `appendSenML()`.
+4. If the peripheral accepts commands, implement `applyCommand()`. If commands are idempotent (schedule-driven), leave `replayCommand()` returning `true`. If they are one-shot, override it to return `false`.
+5. Register it in `normalOperation()` in `src/main.cpp`:
+   ```cpp
+   manager.add(new MyPeripheral(PIN, INTERVAL_MS));
+   ```
+
+No changes to `PeripheralManager` or `FishHubMqttClient` are needed — they discover peripherals at runtime through the `Peripheral` interface.


### PR DESCRIPTION
## Summary

- Rewrote `architecture.md` with accurate source layout (adds `PeripheralManager`, `FishHubMqttClient`, `Schedule`, `DS18B20Sensor`, `RelayActuator`), updated module descriptions, and rewritten boot/command flow diagrams
- Rewrote `configuration.md`: corrected `config.h` table (removed stale `DEVICE_TOKEN`, added `MQTT_HOST`/`MQTT_PORT`/`DEVICE_ID`), updated provisioning steps to reflect the async 202 + status-polling flow, added NVS keys table and atomicity flag explanation
- Updated `index.md`: added `peripherals.md` link, expanded tech stack table with MQTT, peripheral abstraction, and scheduling entries
- Added `docs/peripherals.md`: documents the `Peripheral` interface contract, `PeripheralManager` API, `DS18B20Sensor`, `RelayActuator`, `Schedule`, `FishHubMqttClient`, and a step-by-step guide for adding new peripherals

Closes #38