### PR TITLE
Tag SenML readings with heartbeat vs. change source

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,3 +17,4 @@ platform = native
 lib_deps =
   bblanchon/ArduinoJson @ ^7.3.1
 build_src_filter = -<*>
+build_flags = -I test/stubs

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -21,17 +21,23 @@ bool RelayActuator::tick(time_t now) {
     Serial.printf("Relay %s: %s\n", _name, desired ? "ON" : "OFF");
   }
   if (changed || now - _lastSentAt >= ACTUATOR_HEARTBEAT_S) {
-    _lastSentAt = now;
+    _lastChanged = changed;
+    _lastSentAt  = now;
     return true;
   }
   return false;
 }
 
 void RelayActuator::appendSenML(JsonArray& records, time_t /*now*/) {
-  JsonObject r = records.add<JsonObject>();
+  JsonObject state = records.add<JsonObject>();
   String n = String(_name) + "/state";
-  r["n"]  = n;
-  r["vb"] = _currentState;
+  state["n"]  = n;
+  state["vb"] = _currentState;
+
+  JsonObject src = records.add<JsonObject>();
+  String ns = String(_name) + "/source";
+  src["n"]  = ns;
+  src["vs"] = _lastChanged ? "change" : "heartbeat";
 }
 
 void RelayActuator::applyCommand(JsonObjectConst cmd) {

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -27,5 +27,6 @@ private:
   uint8_t     _pin;
   Schedule    _schedule;
   bool        _currentState = false;
+  bool        _lastChanged  = false;
   time_t      _lastSentAt   = 0;
 };

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+using String = std::string;
+
+#define OUTPUT 0
+#define HIGH   1
+#define LOW    0
+
+inline void pinMode(uint8_t, uint8_t) {}
+inline void digitalWrite(uint8_t, uint8_t) {}
+
+struct SerialClass {
+  template<typename... Args>
+  void printf(const char*, Args...) {}
+} Serial;

--- a/test/test_relay_actuator/test_relay_actuator.cpp
+++ b/test/test_relay_actuator/test_relay_actuator.cpp
@@ -1,0 +1,132 @@
+#include <unity.h>
+#include <ArduinoJson.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+// ── subject under test ────────────────────────────────────────────────────────
+
+#include "../../src/schedule.cpp"
+#include "../../src/peripherals/relay_actuator.cpp"
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// Force the relay into a known state without triggering the schedule.
+// We drive tick() with a time that makes _schedule.isActive() return false
+// (empty schedule → always inactive), then manipulate via applyCommand.
+static const time_t T0 = 1700000000;
+
+// Returns a freshly ticked RelayActuator whose appendSenML result is in `doc`.
+// `changed` indicates whether this tick should represent a state change.
+static void tickAndAppend(RelayActuator& relay, bool triggerChange,
+                          JsonDocument& doc) {
+  JsonArray arr = doc.to<JsonArray>();
+
+  if (triggerChange) {
+    // Apply an override to flip state, then advance time just enough that
+    // tick() sees a change.
+    JsonDocument cmd;
+    cmd["action"] = "set";
+    cmd["state"]  = true;
+    relay.applyCommand(cmd.as<JsonObjectConst>());
+  }
+
+  // Advance time past heartbeat so tick always fires when no change occurred.
+  static time_t t = T0 + ACTUATOR_HEARTBEAT_S;
+  t += ACTUATOR_HEARTBEAT_S;
+  relay.tick(t);
+  relay.appendSenML(arr, t);
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+void test_state_change_emits_change_source(void) {
+  RelayActuator relay("light", 1);
+  relay.begin();
+
+  // Override to ON → tick sees a state change.
+  JsonDocument cmd;
+  cmd["action"] = "set";
+  cmd["state"]  = true;
+  relay.applyCommand(cmd.as<JsonObjectConst>());
+
+  time_t t = T0 + ACTUATOR_HEARTBEAT_S;
+  relay.tick(t);
+
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  relay.appendSenML(arr, t);
+
+  // Find the source entry.
+  const char* src = nullptr;
+  for (JsonObject obj : arr) {
+    const char* n = obj["n"];
+    if (n && std::string(n).find("/source") != std::string::npos) {
+      src = obj["vs"];
+    }
+  }
+  TEST_ASSERT_NOT_NULL(src);
+  TEST_ASSERT_EQUAL_STRING("change", src);
+}
+
+void test_heartbeat_emits_heartbeat_source(void) {
+  RelayActuator relay("light", 1);
+  relay.begin();
+
+  // Tick once to initialise _lastSentAt, with no state change (empty schedule).
+  time_t t1 = T0 + ACTUATOR_HEARTBEAT_S;
+  relay.tick(t1);
+
+  // Second tick: no state change, heartbeat fires.
+  time_t t2 = t1 + ACTUATOR_HEARTBEAT_S;
+  relay.tick(t2);
+
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  relay.appendSenML(arr, t2);
+
+  const char* src = nullptr;
+  for (JsonObject obj : arr) {
+    const char* n = obj["n"];
+    if (n && std::string(n).find("/source") != std::string::npos) {
+      src = obj["vs"];
+    }
+  }
+  TEST_ASSERT_NOT_NULL(src);
+  TEST_ASSERT_EQUAL_STRING("heartbeat", src);
+}
+
+void test_state_entry_always_present(void) {
+  RelayActuator relay("light", 1);
+  relay.begin();
+
+  time_t t = T0 + ACTUATOR_HEARTBEAT_S;
+  relay.tick(t);
+
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  relay.appendSenML(arr, t);
+
+  bool foundState = false;
+  for (JsonObject obj : arr) {
+    const char* n = obj["n"];
+    if (n && std::string(n).find("/state") != std::string::npos) {
+      foundState = true;
+      TEST_ASSERT_TRUE(obj["vb"].is<bool>());
+    }
+  }
+  TEST_ASSERT_TRUE(foundState);
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_state_change_emits_change_source);
+  RUN_TEST(test_heartbeat_emits_heartbeat_source);
+  RUN_TEST(test_state_entry_always_present);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- `RelayActuator` now emits a second SenML sibling record `{"n": "<name>/source", "vs": "change"|"heartbeat"}` alongside the state entry in `appendSenML()`
- `tick()` stores the `changed` flag as `_lastChanged` (new private member) so `appendSenML()` can read it — no interface changes to `Peripheral` or `PeripheralManager`
- Adds `test/test_relay_actuator/` with Arduino stubs (`test/stubs/Arduino.h`) and three native unit tests covering state-change, heartbeat, and state-entry presence

## Depends on

fishhub-oss/fishhub-server#75 — server must handle `"vs"` string SenML values before the `light/source` field lands in InfluxDB.

## Test plan

- [x] `pio run` — compiles clean
- [x] `pio test -e native` — 17/17 tests pass (14 existing + 3 new)

Closes #45