### PR TITLE
Dynamic peripherals via MQTT peripheral config topic

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -13,6 +13,7 @@ public:
 private:
   void connect();
   void onMessage(char* topic, byte* payload, unsigned int len);
+  void onPeripheralConfig(const String& name, byte* payload, unsigned int len);
 
   WiFiClientSecure   _tlsClient;
   PubSubClient       _client;

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -20,8 +20,17 @@ struct PeripheralEntry {
 
 class PeripheralManager {
 public:
+  // Adds a peripheral. If beginAll() has already been called, begin() is
+  // invoked immediately so late-registered peripherals are initialised.
+  // Ownership of the pointer is transferred — remove() will delete it.
   void add(Peripheral* p);
   void beginAll();
+
+  // Removes the peripheral with the given name and deletes the object.
+  void remove(const String& name);
+
+  // Returns true if a peripheral with the given name is registered.
+  bool has(const String& name) const;
 
   // Ticks each peripheral when its interval has elapsed.
   // nowMs is injected so tests can pass a fake counter instead of millis().
@@ -32,8 +41,9 @@ public:
   void dispatchCommand(const String& name, JsonObjectConst cmd);
 
   // Returns the peripheral with the given name, or nullptr if not found.
-  Peripheral* find(const String& name);
+  Peripheral* find(const String& name) const;
 
 private:
   std::vector<PeripheralEntry> _entries;
+  bool _begun = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@
 #include "mqtt_client.h"
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
-#include "peripherals/relay_actuator.h"
 
 #ifndef DS18B20_INTERVAL_MS
 #define DS18B20_INTERVAL_MS 30000
@@ -47,8 +46,8 @@ static void connectToWifi()
 static void normalOperation()
 {
   manager.add(new DS18B20Sensor(ONE_WIRE_PIN, DS18B20_INTERVAL_MS));
-  manager.add(new RelayActuator("light", RELAY_LIGHT_PIN));
   manager.beginAll();
+  // RelayActuator instances are registered dynamically via MQTT peripheral config
   mqttClient.begin(manager);
 }
 

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -1,6 +1,7 @@
 #include "mqtt_client.h"
 #include "nvs_store.h"
 #include "config.h"
+#include "peripherals/relay_actuator.h"
 #include <ArduinoJson.h>
 
 static const unsigned long RECONNECT_INTERVAL_MS = 5000;
@@ -93,18 +94,33 @@ void FishHubMqttClient::connect() {
     return;
   }
 
-  String topic = "fishhub/" + _deviceId + "/commands/#";
-  _client.subscribe(topic.c_str());
-  Serial.printf("MQTT: connected, subscribed to %s\n", topic.c_str());
+  String cmdTopic         = "fishhub/" + _deviceId + "/commands/#";
+  String peripheralsTopic = "fishhub/" + _deviceId + "/peripherals/#";
+  _client.subscribe(cmdTopic.c_str());
+  _client.subscribe(peripheralsTopic.c_str());
+  Serial.printf("MQTT: connected, subscribed to commands and peripherals topics\n");
 }
 
 void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) {
-  // Extract peripheral name from last topic segment: fishhub/<id>/commands/<name>
   String t(topic);
-  int lastSlash = t.lastIndexOf('/');
-  if (lastSlash < 0) return;
-  String peripheralName = t.substring(lastSlash + 1);
+  String prefix = "fishhub/" + _deviceId + "/";
+  if (!t.startsWith(prefix)) return;
 
+  String rest  = t.substring(prefix.length()); // e.g. "commands/light" or "peripherals/light"
+  int slash    = rest.indexOf('/');
+  if (slash < 0) return;
+
+  String segment = rest.substring(0, slash);
+  String name    = rest.substring(slash + 1);
+
+  if (segment == "peripherals") {
+    onPeripheralConfig(name, payload, len);
+    return;
+  }
+
+  if (segment != "commands") return;
+
+  // Command dispatch
   JsonDocument doc;
   DeserializationError err = deserializeJson(doc, payload, len);
   if (err) {
@@ -118,23 +134,59 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
     return;
   }
 
-  Peripheral* peripheral = _manager->find(peripheralName);
+  Peripheral* peripheral = _manager->find(name);
   if (!peripheral) {
-    Serial.printf("MQTT: no peripheral named '%s'\n", peripheralName.c_str());
+    Serial.printf("MQTT: no peripheral named '%s'\n", name.c_str());
     return;
   }
 
   if (!peripheral->replayCommand()) {
-    String nvsKey = String("cmd_") + peripheralName;
+    String nvsKey = String("cmd_") + name;
     String lastId = nvsStore.get(nvsKey.c_str());
     if (lastId == cmdId) {
       Serial.printf("MQTT: duplicate command id=%s for %s — skipped\n",
-                    cmdId, peripheralName.c_str());
+                    cmdId, name.c_str());
       return;
     }
     nvsStore.set(nvsKey.c_str(), String(cmdId));
   }
 
-  Serial.printf("MQTT: dispatching command id=%s to %s\n", cmdId, peripheralName.c_str());
-  _manager->dispatchCommand(peripheralName, doc.as<JsonObjectConst>());
+  Serial.printf("MQTT: dispatching command id=%s to %s\n", cmdId, name.c_str());
+  _manager->dispatchCommand(name, doc.as<JsonObjectConst>());
+}
+
+void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, unsigned int len) {
+  if (len == 0) return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, payload, len)) {
+    Serial.printf("MQTT: bad JSON on peripherals/%s\n", name.c_str());
+    return;
+  }
+
+  const char* op = doc["op"];
+  if (!op) return;
+
+  if (strcmp(op, "delete") == 0) {
+    Serial.printf("MQTT: removing peripheral '%s'\n", name.c_str());
+    _manager->remove(name);
+    return;
+  }
+
+  if (strcmp(op, "create") == 0) {
+    if (_manager->has(name)) {
+      Serial.printf("MQTT: peripheral '%s' already registered — skipping\n", name.c_str());
+      return;
+    }
+    const char* kind = doc["kind"];
+    int pin = doc["pin"] | -1;
+    if (!kind || pin < 0) {
+      Serial.printf("MQTT: peripheral '%s' missing kind or pin\n", name.c_str());
+      return;
+    }
+    if (strcmp(kind, "relay") == 0) {
+      _manager->add(new RelayActuator(name.c_str(), (uint8_t)pin));
+      Serial.printf("MQTT: registered relay '%s' on pin %d\n", name.c_str(), pin);
+    }
+  }
 }

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -6,12 +6,28 @@
 
 void PeripheralManager::add(Peripheral* p) {
   _entries.push_back({p, 0});
+  if (_begun) p->begin();
 }
 
 void PeripheralManager::beginAll() {
   for (auto& e : _entries) {
     e.peripheral->begin();
   }
+  _begun = true;
+}
+
+void PeripheralManager::remove(const String& name) {
+  for (auto it = _entries.begin(); it != _entries.end(); ++it) {
+    if (name == it->peripheral->name()) {
+      delete it->peripheral;
+      _entries.erase(it);
+      return;
+    }
+  }
+}
+
+bool PeripheralManager::has(const String& name) const {
+  return find(name) != nullptr;
 }
 
 String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
@@ -56,7 +72,7 @@ void PeripheralManager::dispatchCommand(const String& name, JsonObjectConst cmd)
   }
 }
 
-Peripheral* PeripheralManager::find(const String& name) {
+Peripheral* PeripheralManager::find(const String& name) const {
   for (auto& e : _entries) {
     if (name == e.peripheral->name()) return e.peripheral;
   }

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -1,8 +1,8 @@
 #include "relay_actuator.h"
 #include <Arduino.h>
 
-RelayActuator::RelayActuator(const char* name, uint8_t pin)
-  : _name(name), _pin(pin) {}
+RelayActuator::RelayActuator(std::string name, uint8_t pin)
+  : _name(std::move(name)), _pin(pin) {}
 
 void RelayActuator::begin() {
   pinMode(_pin, OUTPUT);
@@ -18,7 +18,7 @@ bool RelayActuator::tick(time_t now) {
     // Active-low: LOW energizes the relay (on), HIGH de-energizes (off)
     digitalWrite(_pin, desired ? LOW : HIGH);
     _currentState = desired;
-    Serial.printf("Relay %s: %s\n", _name, desired ? "ON" : "OFF");
+    Serial.printf("Relay %s: %s\n", _name.c_str(), desired ? "ON" : "OFF");
   }
   if (changed || now - _lastSentAt >= ACTUATOR_HEARTBEAT_S) {
     _lastChanged = changed;
@@ -30,12 +30,12 @@ bool RelayActuator::tick(time_t now) {
 
 void RelayActuator::appendSenML(JsonArray& records, time_t /*now*/) {
   JsonObject state = records.add<JsonObject>();
-  String n = String(_name) + "/state";
+  String n = String(_name.c_str()) + "/state";
   state["n"]  = n;
   state["vb"] = _currentState;
 
   JsonObject src = records.add<JsonObject>();
-  String ns = String(_name) + "/source";
+  String ns = String(_name.c_str()) + "/source";
   src["n"]  = ns;
   src["vs"] = _lastChanged ? "change" : "heartbeat";
 }

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include <string>
+#endif
+
 #include "peripheral.h"
 #include "schedule.h"
 
@@ -10,20 +15,20 @@
 
 class RelayActuator : public Peripheral {
 public:
-  RelayActuator(const char* name, uint8_t pin);
+  RelayActuator(std::string name, uint8_t pin);
 
   void        begin() override;
   uint32_t    intervalMs() const override { return 1000; }
   bool        tick(time_t now) override;
   void        appendSenML(JsonArray& records, time_t now) override;
   void        applyCommand(JsonObjectConst cmd) override;
-  const char* name() const override { return _name; }
+  const char* name() const override { return _name.c_str(); }
 
   // Schedules are idempotent — retained messages should re-apply on reboot.
   bool replayCommand() const override { return true; }
 
 private:
-  const char* _name;
+  std::string _name;
   uint8_t     _pin;
   Schedule    _schedule;
   bool        _currentState = false;

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -198,6 +198,38 @@ void test_schedule_load_clears_override() {
   TEST_ASSERT_FALSE(s.hasOverride());
 }
 
+// ── PeripheralManager remove / has ───────────────────────────────────────────
+
+void test_manager_remove(void) {
+  PeripheralManager mgr;
+  mgr.add(new MockPeripheral("light", 1000));
+  mgr.beginAll();
+  mgr.remove("light");
+  TEST_ASSERT_NULL(mgr.find("light"));
+}
+
+void test_manager_has(void) {
+  PeripheralManager mgr;
+  MockPeripheral p("light", 1000);
+  mgr.add(&p);
+  mgr.beginAll();
+  TEST_ASSERT_TRUE(mgr.has("light"));
+  TEST_ASSERT_FALSE(mgr.has("pump"));
+}
+
+void test_manager_add_after_begin_calls_begin(void) {
+  PeripheralManager mgr;
+  mgr.beginAll();
+  MockPeripheral* p = new MockPeripheral("late", 1000);
+  mgr.add(p);
+  // A peripheral added after beginAll() should be ticked immediately
+  // at t=1000ms without an explicit beginAll() call.
+  String out = mgr.tickAll(0, 1000);
+  TEST_ASSERT_FALSE(out.empty());
+  TEST_ASSERT_EQUAL_INT(1, p->tickCount);
+  mgr.remove("late");
+}
+
 // ── entry point ──────────────────────────────────────────────────────────────
 
 void setUp(void) {}
@@ -223,5 +255,8 @@ int main(void) {
   RUN_TEST(test_schedule_override_true);
   RUN_TEST(test_schedule_override_false);
   RUN_TEST(test_schedule_load_clears_override);
+  RUN_TEST(test_manager_remove);
+  RUN_TEST(test_manager_has);
+  RUN_TEST(test_manager_add_after_begin_calls_begin);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- `PeripheralManager` gains `remove()` (deletes the object), `has()`, and a `_begun` flag so `add()` auto-calls `begin()` on late-registered peripherals
- `RelayActuator` stores its name as `std::string` to prevent dangling pointer after MQTT callback buffer reuse
- `FishHubMqttClient` subscribes to `fishhub/{id}/peripherals/#` and routes by topic segment; `onPeripheralConfig()` branches on `op: "create"` / `op: "delete"`
- `main.cpp` drops the hardcoded `RelayActuator` — relay peripherals arrive exclusively via retained MQTT from the server

## Test plan

- [x] `pio run` — compiles clean
- [x] `pio test -e native` — 20/20 tests pass (17 existing + 3 new)

Closes #49