### PR TITLE
Fix MQTT reconnect loop on startup

### DIFF
--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -62,6 +62,7 @@ void FishHubMqttClient::begin(PeripheralManager& manager) {
   });
 
   connect();
+  _lastConnectAttempt = millis();
 }
 
 void FishHubMqttClient::loop() {


### PR DESCRIPTION
## Summary

- `_lastConnectAttempt` was initialised to `0`, so on the first `loop()` call after boot (where `millis()` is already well past 5000 ms due to Wi-Fi + NTP setup), the reconnect condition fired immediately and `connect()` was called a second time right after `begin()` had just connected successfully.
- Fix: set `_lastConnectAttempt = millis()` at the end of `begin()`, after the initial `connect()` call, so the 5-second cooldown starts from the real boot time.

## Test plan

- [ ] Flash firmware and observe Serial output — only one `MQTT: connecting` line on boot, not two
- [ ] Disconnect broker to verify reconnect fires after ~5 s, not immediately

Closes #51