### PR TITLE
All peripherals dynamic via MQTT, persisted in NVS

### DIFF
--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -9,6 +9,7 @@ using String = std::string;
 #endif
 
 #include <ArduinoJson.h>
+#include <functional>
 #include <vector>
 #include <time.h>
 #include "peripheral.h"
@@ -16,6 +17,8 @@ using String = std::string;
 struct PeripheralEntry {
   Peripheral* peripheral;
   uint32_t    lastTickedAt;
+  const char* kind = nullptr;
+  int         pin  = -1;
 };
 
 class PeripheralManager {
@@ -23,7 +26,10 @@ public:
   // Adds a peripheral. If beginAll() has already been called, begin() is
   // invoked immediately so late-registered peripherals are initialised.
   // Ownership of the pointer is transferred — remove() will delete it.
-  void add(Peripheral* p);
+  void add(Peripheral* p, const char* kind = nullptr, int pin = -1);
+
+  // Iterates all entries, calling fn(peripheral, kind, pin) for each.
+  void forEach(std::function<void(Peripheral*, const char*, int)> fn) const;
   void beginAll();
 
   // Removes the peripheral with the given name and deletes the object.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include "pins.h"
 #include "nvs_store.h"
 #include "provisioning.h"
@@ -7,10 +8,7 @@
 #include "mqtt_client.h"
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
-
-#ifndef DS18B20_INTERVAL_MS
-#define DS18B20_INTERVAL_MS 30000
-#endif
+#include "peripherals/relay_actuator.h"
 
 static PeripheralManager manager;
 static FishHubMqttClient mqttClient;
@@ -24,7 +22,7 @@ static void boot()
 
   Serial.println("NVS key status:");
   for (const char *key : {"wifi_ssid", "wifi_pass", "device_id", "device_jwt",
-                           "mqtt_username", "mqtt_host", "provisioned"})
+                          "mqtt_username", "mqtt_host", "provisioned"})
   {
     Serial.printf("  NVS %-14s %s\n", key,
                   nvsStore.get(key).isEmpty() ? "MISSING" : "present");
@@ -43,11 +41,40 @@ static void connectToWifi()
   waitForNtp();
 }
 
+// Restore peripherals persisted in NVS so the device is functional
+// immediately on boot, before retained MQTT messages are re-delivered.
+static void restorePeripherals()
+{
+  String json = nvsStore.get("peripherals");
+  if (json.isEmpty()) return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, json)) {
+    Serial.println("NVS: failed to parse peripherals JSON — skipping restore");
+    return;
+  }
+
+  JsonArray arr = doc.as<JsonArray>();
+  for (JsonObject p : arr) {
+    const char* name = p["name"];
+    const char* kind = p["kind"];
+    int pin          = p["pin"] | -1;
+    if (!name || !kind || pin < 0) continue;
+
+    if (strcmp(kind, "ds18b20") == 0) {
+      manager.add(new DS18B20Sensor(name, (uint8_t)pin), "ds18b20", pin);
+      Serial.printf("NVS: restored ds18b20 '%s' on pin %d\n", name, pin);
+    } else if (strcmp(kind, "relay") == 0) {
+      manager.add(new RelayActuator(name, (uint8_t)pin), "relay", pin);
+      Serial.printf("NVS: restored relay '%s' on pin %d\n", name, pin);
+    }
+  }
+}
+
 static void normalOperation()
 {
-  manager.add(new DS18B20Sensor(ONE_WIRE_PIN, DS18B20_INTERVAL_MS));
+  restorePeripherals();
   manager.beginAll();
-  // RelayActuator instances are registered dynamically via MQTT peripheral config
   mqttClient.begin(manager);
 }
 

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -2,6 +2,7 @@
 #include "nvs_store.h"
 #include "config.h"
 #include "peripherals/relay_actuator.h"
+#include "peripherals/ds18b20_sensor.h"
 #include <ArduinoJson.h>
 
 static const unsigned long RECONNECT_INTERVAL_MS = 5000;
@@ -57,6 +58,7 @@ void FishHubMqttClient::begin(PeripheralManager& manager) {
 
   _client.setClient(_tlsClient);
   _client.setBufferSize(1024);
+  _client.setKeepAlive(30);
   _client.setServer(_mqttHost.c_str(), _mqttPort);
   _client.setCallback([this](char* topic, byte* payload, unsigned int len) {
     onMessage(topic, payload, len);
@@ -156,6 +158,22 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
   _manager->dispatchCommand(name, doc.as<JsonObjectConst>());
 }
 
+// Persist the current peripheral list to NVS as a JSON array.
+static void savePeripheralsToNVS(PeripheralManager* mgr) {
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  mgr->forEach([&arr](Peripheral* p, const char* kind, int pin) {
+    if (!kind || pin < 0) return;
+    JsonObject obj = arr.add<JsonObject>();
+    obj["name"] = p->name();
+    obj["kind"] = kind;
+    obj["pin"]  = pin;
+  });
+  String json;
+  serializeJson(doc, json);
+  nvsStore.set("peripherals", json);
+}
+
 void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, unsigned int len) {
   if (len == 0) return;
 
@@ -171,6 +189,7 @@ void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, un
   if (strcmp(op, "delete") == 0) {
     Serial.printf("MQTT: removing peripheral '%s'\n", name.c_str());
     _manager->remove(name);
+    savePeripheralsToNVS(_manager);
     return;
   }
 
@@ -186,8 +205,15 @@ void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, un
       return;
     }
     if (strcmp(kind, "relay") == 0) {
-      _manager->add(new RelayActuator(name.c_str(), (uint8_t)pin));
+      _manager->add(new RelayActuator(name.c_str(), (uint8_t)pin), "relay", pin);
       Serial.printf("MQTT: registered relay '%s' on pin %d\n", name.c_str(), pin);
+    } else if (strcmp(kind, "ds18b20") == 0) {
+      _manager->add(new DS18B20Sensor(name.c_str(), (uint8_t)pin), "ds18b20", pin);
+      Serial.printf("MQTT: registered ds18b20 '%s' on pin %d\n", name.c_str(), pin);
+    } else {
+      Serial.printf("MQTT: unknown peripheral kind '%s'\n", kind);
+      return;
     }
+    savePeripheralsToNVS(_manager);
   }
 }

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -4,9 +4,20 @@
 // millis() not available on native — callers always inject nowMs
 #endif
 
-void PeripheralManager::add(Peripheral* p) {
-  _entries.push_back({p, 0});
+void PeripheralManager::add(Peripheral* p, const char* kind, int pin) {
+  PeripheralEntry e;
+  e.peripheral   = p;
+  e.lastTickedAt = 0;
+  e.kind         = kind;
+  e.pin          = pin;
+  _entries.push_back(e);
   if (_begun) p->begin();
+}
+
+void PeripheralManager::forEach(std::function<void(Peripheral*, const char*, int)> fn) const {
+  for (const auto& e : _entries) {
+    fn(e.peripheral, e.kind, e.pin);
+  }
 }
 
 void PeripheralManager::beginAll() {

--- a/src/peripherals/ds18b20_sensor.cpp
+++ b/src/peripherals/ds18b20_sensor.cpp
@@ -1,8 +1,8 @@
 #include "ds18b20_sensor.h"
 #include <Arduino.h>
 
-DS18B20Sensor::DS18B20Sensor(uint8_t pin, uint32_t intervalMs)
-  : _ow(pin), _sensors(&_ow), _lastTemp(0.0f), _intervalMs(intervalMs) {}
+DS18B20Sensor::DS18B20Sensor(std::string name, uint8_t pin, uint32_t intervalMs)
+  : _name(std::move(name)), _ow(pin), _sensors(&_ow), _lastTemp(0.0f), _intervalMs(intervalMs) {}
 
 void DS18B20Sensor::begin() {
   _sensors.begin();
@@ -23,7 +23,8 @@ bool DS18B20Sensor::tick(time_t /*now*/) {
 
 void DS18B20Sensor::appendSenML(JsonArray& records, time_t /*now*/) {
   JsonObject r = records.add<JsonObject>();
-  r["n"] = "temperature";
+  String n = String(_name.c_str()) + "/temperature";
+  r["n"] = n;
   r["u"] = "Cel";
   r["v"] = _lastTemp;
 }

--- a/src/peripherals/ds18b20_sensor.h
+++ b/src/peripherals/ds18b20_sensor.h
@@ -1,20 +1,26 @@
 #pragma once
 
+#include <string>
 #include <OneWire.h>
 #include <DallasTemperature.h>
 #include "peripheral.h"
 
+#ifndef DS18B20_INTERVAL_MS
+#define DS18B20_INTERVAL_MS 30000
+#endif
+
 class DS18B20Sensor : public Peripheral {
 public:
-  DS18B20Sensor(uint8_t pin, uint32_t intervalMs);
+  DS18B20Sensor(std::string name, uint8_t pin, uint32_t intervalMs = DS18B20_INTERVAL_MS);
 
-  void     begin() override;
-  uint32_t intervalMs() const override { return _intervalMs; }
-  bool     tick(time_t now) override;
-  void     appendSenML(JsonArray& records, time_t now) override;
-  const char* name() const override { return "temperature"; }
+  void        begin() override;
+  uint32_t    intervalMs() const override { return _intervalMs; }
+  bool        tick(time_t now) override;
+  void        appendSenML(JsonArray& records, time_t now) override;
+  const char* name() const override { return _name.c_str(); }
 
 private:
+  std::string       _name;
   OneWire           _ow;
   DallasTemperature _sensors;
   float             _lastTemp;


### PR DESCRIPTION
## Summary

- **DS18B20Sensor** now takes a `name` and `pin` at construction (same pattern as `RelayActuator`); `name()` returns the configured name and the SenML field is `<name>/temperature`
- **PeripheralManager** `add()` accepts optional `kind`/`pin` metadata stored in `PeripheralEntry`; new `forEach()` iterates all entries with their metadata
- **`onPeripheralConfig()`** handles `kind: "ds18b20"` in addition to `"relay"`; both `create` and `delete` paths call `savePeripheralsToNVS()` which serialises the full peripheral list to JSON under the `"peripherals"` NVS key
- **`normalOperation()`** calls `restorePeripherals()` before `mqttClient.begin()`, re-instantiating all persisted peripherals so the device is fully functional immediately on reboot — before retained MQTT messages are re-delivered

## Test plan

- [x] `pio run` succeeds
- [x] All 20 native unit tests pass (`pio test -e native`)
- [ ] Register a ds18b20 peripheral via the web UI; verify it appears in Serial output and publishes readings
- [ ] Reboot the device; verify the ds18b20 is restored from NVS before any MQTT message arrives
- [ ] Remove the peripheral via the web UI; verify it disappears from NVS and stops publishing

Closes #52