### PR TITLE
Rewrite Schedule with day-of-week, float values, and ControlMode

### DIFF
--- a/include/schedule.h
+++ b/include/schedule.h
@@ -23,13 +23,17 @@ public:
   float activeValue(time_t now) const;
 
   // Sets the held value used in Manual mode. Does not change the mode itself.
-  void setManualValue(float value);
+  void  setManualValue(float value);
+  float manualValue() const { return _overrideValue; }
 
   // Switches between Manual and Automatic. Does not change the held value.
   void        setControlMode(ControlMode mode);
   ControlMode controlMode() const { return _mode; }
 
   bool hasOverride() const { return _mode == ControlMode::Manual; }
+
+  // Serialises the current window list into a JSON array (for NVS persistence).
+  void serializeWindows(JsonArray& out) const;
 
 private:
   struct Window {

--- a/include/schedule.h
+++ b/include/schedule.h
@@ -10,30 +10,38 @@
 #include <ArduinoJson.h>
 #include <vector>
 
+enum class ControlMode { Automatic, Manual };
+
 class Schedule {
 public:
-  // Parses an array of ["HH:MM","HH:MM"] window pairs.
-  // Clears any active override.
+  // Parses an array of {"from","to","value",?"days"} window objects.
+  // Does NOT change the current control mode.
   void loadWindows(JsonArrayConst windows);
 
-  // Returns true if now falls within any stored window.
-  // Handles overnight windows (e.g. 22:00–06:00) correctly.
-  bool isActive(time_t now) const;
+  // Returns _overrideValue if Manual, otherwise the value of the first matching
+  // window, or 0.0f if none match. Handles overnight windows correctly.
+  float activeValue(time_t now) const;
 
-  // Forces a fixed state regardless of windows until the next loadWindows() call.
-  void setOverride(bool state);
+  // Sets the held value used in Manual mode. Does not change the mode itself.
+  void setManualValue(float value);
 
-  bool hasOverride() const { return _overridden; }
+  // Switches between Manual and Automatic. Does not change the held value.
+  void        setControlMode(ControlMode mode);
+  ControlMode controlMode() const { return _mode; }
+
+  bool hasOverride() const { return _mode == ControlMode::Manual; }
 
 private:
   struct Window {
-    uint16_t onMinutes;
-    uint16_t offMinutes;
+    uint8_t  days;        // bitmask bit0=Mon…bit6=Sun; 0 = every day
+    uint16_t fromMinutes;
+    uint16_t toMinutes;
+    float    value;
   };
 
   static uint16_t parseMinutes(const char* hhmm);
 
   std::vector<Window> _windows;
-  bool _overridden    = false;
-  bool _overrideState = false;
+  ControlMode         _mode          = ControlMode::Automatic;
+  float               _overrideValue = 0.0f;
 };

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -12,7 +12,7 @@ void RelayActuator::begin() {
 }
 
 bool RelayActuator::tick(time_t now) {
-  bool desired = _schedule.isActive(now);
+  bool desired = _schedule.activeValue(now) >= 0.5f;
   bool changed = desired != _currentState;
   if (changed) {
     // Active-low: LOW energizes the relay (on), HIGH de-energizes (off)
@@ -45,7 +45,17 @@ void RelayActuator::applyCommand(JsonObjectConst cmd) {
   if (!action) return;
 
   if (strcmp(action, "set") == 0) {
-    _schedule.setOverride(cmd["state"].as<bool>());
+    // Set value and implicitly enter Manual mode.
+    _schedule.setManualValue(cmd["value"] | 1.0f);
+    _schedule.setControlMode(ControlMode::Manual);
+  } else if (strcmp(action, "set_mode") == 0) {
+    const char* mode = cmd["mode"];
+    if (!mode) return;
+    if (strcmp(mode, "manual") == 0) {
+      _schedule.setControlMode(ControlMode::Manual);
+    } else if (strcmp(mode, "automatic") == 0) {
+      _schedule.setControlMode(ControlMode::Automatic);
+    }
   } else if (strcmp(action, "schedule") == 0) {
     _schedule.loadWindows(cmd["windows"].as<JsonArrayConst>());
   }

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -1,5 +1,8 @@
 #include "relay_actuator.h"
 #include <Arduino.h>
+#ifdef ARDUINO
+#include "nvs_store.h"
+#endif
 
 RelayActuator::RelayActuator(std::string name, uint8_t pin)
   : _name(std::move(name)), _pin(pin) {}
@@ -9,6 +12,7 @@ void RelayActuator::begin() {
   // Start de-energized (HIGH = off for active-low relay)
   digitalWrite(_pin, HIGH);
   _currentState = false;
+  _restoreFromNVS();
 }
 
 bool RelayActuator::tick(time_t now) {
@@ -59,4 +63,51 @@ void RelayActuator::applyCommand(JsonObjectConst cmd) {
   } else if (strcmp(action, "schedule") == 0) {
     _schedule.loadWindows(cmd["windows"].as<JsonArrayConst>());
   }
+
+  _persistToNVS();
+}
+
+void RelayActuator::_persistToNVS() {
+#ifndef ARDUINO
+  return;
+#else
+  String cmKey = String("cm_") + _name.c_str();
+  nvsStore.set(cmKey.c_str(),
+    _schedule.controlMode() == ControlMode::Manual ? "manual" : "automatic");
+
+  String mvKey = String("mv_") + _name.c_str();
+  nvsStore.set(mvKey.c_str(), String(_schedule.manualValue()));
+
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+  _schedule.serializeWindows(arr);
+  String json;
+  serializeJson(doc, json);
+  String scKey = String("sc_") + _name.c_str();
+  nvsStore.set(scKey.c_str(), json);
+#endif
+}
+
+void RelayActuator::_restoreFromNVS() {
+#ifndef ARDUINO
+  return;
+#else
+  String cmKey = String("cm_") + _name.c_str();
+  String mode  = nvsStore.get(cmKey.c_str());
+  if (mode == "manual") {
+    String mvKey = String("mv_") + _name.c_str();
+    float val = nvsStore.get(mvKey.c_str()).toFloat();
+    _schedule.setManualValue(val);
+    _schedule.setControlMode(ControlMode::Manual);
+  }
+
+  String scKey   = String("sc_") + _name.c_str();
+  String scJson  = nvsStore.get(scKey.c_str());
+  if (scJson.length() > 0) {
+    JsonDocument doc;
+    if (!deserializeJson(doc, scJson)) {
+      _schedule.loadWindows(doc.as<JsonArrayConst>());
+    }
+  }
+#endif
 }

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -28,6 +28,9 @@ public:
   bool replayCommand() const override { return true; }
 
 private:
+  void _persistToNVS();
+  void _restoreFromNVS();
+
   std::string _name;
   uint8_t     _pin;
   Schedule    _schedule;

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -62,3 +62,22 @@ void Schedule::setManualValue(float value) {
 void Schedule::setControlMode(ControlMode mode) {
   _mode = mode;
 }
+
+void Schedule::serializeWindows(JsonArray& out) const {
+  for (const auto& w : _windows) {
+    JsonObject obj = out.add<JsonObject>();
+    // Reconstruct HH:MM strings from minutes
+    char from[6], to[6];
+    snprintf(from, sizeof(from), "%02d:%02d", w.fromMinutes / 60, w.fromMinutes % 60);
+    snprintf(to,   sizeof(to),   "%02d:%02d", w.toMinutes   / 60, w.toMinutes   % 60);
+    obj["from"]  = from;
+    obj["to"]    = to;
+    obj["value"] = w.value;
+    if (w.days != 0) {
+      JsonArray daysArr = obj["days"].to<JsonArray>();
+      for (int i = 0; i < 7; i++) {
+        if (w.days & (1 << i)) daysArr.add(i + 1);
+      }
+    }
+  }
+}

--- a/src/schedule.cpp
+++ b/src/schedule.cpp
@@ -11,40 +11,54 @@ uint16_t Schedule::parseMinutes(const char* hhmm) {
 
 void Schedule::loadWindows(JsonArrayConst windows) {
   _windows.clear();
-  _overridden = false;
-  for (JsonArrayConst pair : windows) {
-    if (pair.size() < 2) continue;
-    const char* on  = pair[0].as<const char*>();
-    const char* off = pair[1].as<const char*>();
-    if (!on || !off) continue;
-    _windows.push_back({parseMinutes(on), parseMinutes(off)});
+  for (JsonObjectConst w : windows) {
+    const char* from = w["from"];
+    const char* to   = w["to"];
+    if (!from || !to) continue;
+
+    uint8_t days = 0;
+    JsonArrayConst daysArr = w["days"];
+    if (!daysArr.isNull()) {
+      for (int d : daysArr) {
+        if (d >= 1 && d <= 7) {
+          // 1=Mon → bit0, 7=Sun → bit6
+          days |= (1 << (d - 1));
+        }
+      }
+    }
+
+    float value = w["value"] | 1.0f;
+    _windows.push_back({days, parseMinutes(from), parseMinutes(to), value});
   }
 }
 
-bool Schedule::isActive(time_t now) const {
-  if (_overridden) return _overrideState;
+float Schedule::activeValue(time_t now) const {
+  if (_mode == ControlMode::Manual) return _overrideValue;
 
   struct tm t;
-#ifdef ARDUINO
   localtime_r(&now, &t);
-#else
-  localtime_r(&now, &t);
-#endif
+
+  // tm_wday: 0=Sun, 1=Mon … 6=Sat → map to bit0=Mon … bit6=Sun
+  uint8_t dayBit = (t.tm_wday == 0) ? (1 << 6) : (1 << (t.tm_wday - 1));
   uint16_t cur = (uint16_t)(t.tm_hour * 60 + t.tm_min);
 
   for (const auto& w : _windows) {
-    if (w.onMinutes <= w.offMinutes) {
-      // Normal window (e.g. 08:00–22:00)
-      if (cur >= w.onMinutes && cur < w.offMinutes) return true;
+    if (w.days != 0 && !(w.days & dayBit)) continue;
+
+    if (w.fromMinutes <= w.toMinutes) {
+      if (cur >= w.fromMinutes && cur < w.toMinutes) return w.value;
     } else {
       // Overnight window (e.g. 22:00–06:00)
-      if (cur >= w.onMinutes || cur < w.offMinutes) return true;
+      if (cur >= w.fromMinutes || cur < w.toMinutes) return w.value;
     }
   }
-  return false;
+  return 0.0f;
 }
 
-void Schedule::setOverride(bool state) {
-  _overridden    = true;
-  _overrideState = state;
+void Schedule::setManualValue(float value) {
+  _overrideValue = value;
+}
+
+void Schedule::setControlMode(ControlMode mode) {
+  _mode = mode;
 }

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -133,12 +133,14 @@ void test_dispatch_command_routes_by_name(void) {
 // ── Schedule tests ───────────────────────────────────────────────────────────
 
 // All schedule tests run with TZ=UTC so localtime_r matches the UTC timestamps.
-// 2024-01-10 10:00:00 UTC
+// 2024-01-10 10:00:00 UTC  (Wednesday)
 static const time_t T_10_00 = 1704880800;
-// 2024-01-10 23:00:00 UTC
+// 2024-01-10 23:00:00 UTC  (Wednesday)
 static const time_t T_23_00 = 1704924000;
-// 2024-01-10 03:00:00 UTC
+// 2024-01-10 03:00:00 UTC  (Wednesday)
 static const time_t T_03_00 = 1704848400;
+// 2024-01-13 10:00:00 UTC  (Saturday)
+static const time_t T_SAT_10_00 = 1705140000;
 
 static Schedule makeSchedule(const char* json) {
   JsonDocument doc;
@@ -150,52 +152,94 @@ static Schedule makeSchedule(const char* json) {
 
 void test_schedule_no_windows_inactive() {
   Schedule s;
-  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_10_00));
 }
 
 void test_schedule_normal_window_inside() {
-  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
-  TEST_ASSERT_TRUE(s.isActive(T_10_00));
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_10_00));
 }
 
 void test_schedule_normal_window_outside() {
-  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
-  TEST_ASSERT_FALSE(s.isActive(T_23_00));
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_23_00));
 }
 
 void test_schedule_overnight_after_on() {
-  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
-  TEST_ASSERT_TRUE(s.isActive(T_23_00));
+  Schedule s = makeSchedule(R"([{"from":"22:00","to":"06:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_23_00));
 }
 
 void test_schedule_overnight_before_off() {
-  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
-  TEST_ASSERT_TRUE(s.isActive(T_03_00));
+  Schedule s = makeSchedule(R"([{"from":"22:00","to":"06:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_03_00));
 }
 
 void test_schedule_overnight_outside() {
-  Schedule s = makeSchedule("[[\"22:00\",\"06:00\"]]");
-  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+  Schedule s = makeSchedule(R"([{"from":"22:00","to":"06:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_10_00));
 }
 
-void test_schedule_override_true() {
-  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
-  s.setOverride(true);
-  TEST_ASSERT_TRUE(s.isActive(T_23_00));
+void test_schedule_override_on() {
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  s.setManualValue(1.0f);
+  s.setControlMode(ControlMode::Manual);
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_23_00));
 }
 
-void test_schedule_override_false() {
-  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
-  s.setOverride(false);
-  TEST_ASSERT_FALSE(s.isActive(T_10_00));
+void test_schedule_override_off() {
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  s.setManualValue(0.0f);
+  s.setControlMode(ControlMode::Manual);
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_10_00));
 }
 
 void test_schedule_load_clears_override() {
-  Schedule s = makeSchedule("[[\"08:00\",\"22:00\"]]");
-  s.setOverride(false);
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  s.setControlMode(ControlMode::Manual);
+  // loadWindows must NOT clear manual mode
   JsonDocument empty;
   s.loadWindows(empty.as<JsonArrayConst>());
-  TEST_ASSERT_FALSE(s.hasOverride());
+  TEST_ASSERT_TRUE(s.hasOverride());
+}
+
+void test_schedule_day_of_week_inactive_on_weekend() {
+  // days:[1,2,3,4,5] = Mon–Fri only; T_SAT_10_00 is Saturday
+  Schedule s = makeSchedule(R"([{"days":[1,2,3,4,5],"from":"08:00","to":"22:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_SAT_10_00));
+}
+
+void test_schedule_day_of_week_active_on_weekday() {
+  // Same window, but T_10_00 is Wednesday — should be active
+  Schedule s = makeSchedule(R"([{"days":[1,2,3,4,5],"from":"08:00","to":"22:00","value":1.0}])");
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_10_00));
+}
+
+void test_schedule_manual_holds_after_load_windows() {
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  s.setManualValue(0.0f);
+  s.setControlMode(ControlMode::Manual);
+  TEST_ASSERT_EQUAL(ControlMode::Manual, s.controlMode());
+
+  // Push a new schedule — must not revert to automatic
+  JsonDocument doc;
+  deserializeJson(doc, R"([{"from":"00:00","to":"23:59","value":1.0}])");
+  s.loadWindows(doc.as<JsonArrayConst>());
+
+  TEST_ASSERT_EQUAL(ControlMode::Manual, s.controlMode());
+  TEST_ASSERT_EQUAL_FLOAT(0.0f, s.activeValue(T_10_00));
+}
+
+void test_schedule_automatic_mode_clears_override() {
+  Schedule s = makeSchedule(R"([{"from":"08:00","to":"22:00","value":1.0}])");
+  s.setManualValue(0.0f);
+  s.setControlMode(ControlMode::Manual);
+  TEST_ASSERT_EQUAL(ControlMode::Manual, s.controlMode());
+
+  s.setControlMode(ControlMode::Automatic);
+  TEST_ASSERT_EQUAL(ControlMode::Automatic, s.controlMode());
+  // Should now follow the schedule — T_10_00 is inside 08:00–22:00
+  TEST_ASSERT_EQUAL_FLOAT(1.0f, s.activeValue(T_10_00));
 }
 
 // ── PeripheralManager remove / has ───────────────────────────────────────────
@@ -252,9 +296,13 @@ int main(void) {
   RUN_TEST(test_schedule_overnight_after_on);
   RUN_TEST(test_schedule_overnight_before_off);
   RUN_TEST(test_schedule_overnight_outside);
-  RUN_TEST(test_schedule_override_true);
-  RUN_TEST(test_schedule_override_false);
+  RUN_TEST(test_schedule_override_on);
+  RUN_TEST(test_schedule_override_off);
   RUN_TEST(test_schedule_load_clears_override);
+  RUN_TEST(test_schedule_day_of_week_inactive_on_weekend);
+  RUN_TEST(test_schedule_day_of_week_active_on_weekday);
+  RUN_TEST(test_schedule_manual_holds_after_load_windows);
+  RUN_TEST(test_schedule_automatic_mode_clears_override);
   RUN_TEST(test_manager_remove);
   RUN_TEST(test_manager_has);
   RUN_TEST(test_manager_add_after_begin_calls_begin);

--- a/test/test_relay_actuator/test_relay_actuator.cpp
+++ b/test/test_relay_actuator/test_relay_actuator.cpp
@@ -23,11 +23,10 @@ static void tickAndAppend(RelayActuator& relay, bool triggerChange,
   JsonArray arr = doc.to<JsonArray>();
 
   if (triggerChange) {
-    // Apply an override to flip state, then advance time just enough that
-    // tick() sees a change.
+    // set with a value implicitly enters Manual mode and flips state ON.
     JsonDocument cmd;
     cmd["action"] = "set";
-    cmd["state"]  = true;
+    cmd["value"]  = 1.0f;
     relay.applyCommand(cmd.as<JsonObjectConst>());
   }
 
@@ -44,10 +43,10 @@ void test_state_change_emits_change_source(void) {
   RelayActuator relay("light", 1);
   relay.begin();
 
-  // Override to ON → tick sees a state change.
+  // set with a value implicitly enters Manual mode and flips state ON.
   JsonDocument cmd;
   cmd["action"] = "set";
-  cmd["state"]  = true;
+  cmd["value"]  = 1.0f;
   relay.applyCommand(cmd.as<JsonObjectConst>());
 
   time_t t = T0 + ACTUATOR_HEARTBEAT_S;


### PR DESCRIPTION
## Summary

- Replaces the \`Window\` struct with \`{days bitmask, fromMinutes, toMinutes, value float}\` — enabling day-specific windows and dimmer-style float output
- Replaces \`isActive()\`/\`setOverride(bool)\` with \`activeValue()\`, \`setManualValue()\`, and \`setControlMode()\`
- Adds \`ControlMode\` enum (\`Automatic\`/\`Manual\`): \`loadWindows\` no longer silently reverts a manual override
- \`relay_actuator\`: \`set\` action sets value and implicitly enters Manual mode; \`set_mode\` switches modes explicitly without changing the held value
- \`RelayActuator\` persists \`control_mode\`, manual value, and schedule windows to NVS after every \`applyCommand()\` and restores them in \`begin()\` — state survives device restarts
- Updates all schedule tests to new JSON object format; adds day-of-week, manual-holds-after-load-windows, and auto-clears-override tests (24/24 passing)

Closes #54