### PR TITLE
feat: subscribe to config topic and apply timezone from server

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -14,6 +14,7 @@ public:
 private:
   void connect();
   void onMessage(char* topic, byte* payload, unsigned int len);
+  void onConfig(byte* payload, unsigned int len);
   void onPeripheralConfig(const String& name, byte* payload, unsigned int len);
 
   WiFiClientSecure   _tlsClient;

--- a/include/nvs_store.h
+++ b/include/nvs_store.h
@@ -10,6 +10,8 @@ public:
   void   remove(const char* key);
   void   clear();
   bool   isProvisioned();
+  String readTimezone();
+  void   writeTimezone(const String& tz);
 
 private:
   Preferences _prefs;

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -99,9 +99,11 @@ void FishHubMqttClient::connect() {
 
   String cmdTopic         = "fishhub/" + _deviceId + "/commands/#";
   String peripheralsTopic = "fishhub/" + _deviceId + "/peripherals/#";
+  String configTopic      = "fishhub/" + _deviceId + "/config";
   _client.subscribe(cmdTopic.c_str());
   _client.subscribe(peripheralsTopic.c_str());
-  Serial.printf("MQTT: connected, subscribed to commands and peripherals topics\n");
+  _client.subscribe(configTopic.c_str());
+  Serial.printf("MQTT: connected, subscribed to commands, peripherals and config topics\n");
 }
 
 void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) {
@@ -109,8 +111,14 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
   String prefix = "fishhub/" + _deviceId + "/";
   if (!t.startsWith(prefix)) return;
 
-  String rest  = t.substring(prefix.length()); // e.g. "commands/light" or "peripherals/light"
-  int slash    = rest.indexOf('/');
+  String rest  = t.substring(prefix.length()); // e.g. "commands/light", "peripherals/light", "config"
+
+  if (rest == "config") {
+    onConfig(payload, len);
+    return;
+  }
+
+  int slash = rest.indexOf('/');
   if (slash < 0) return;
 
   String segment = rest.substring(0, slash);
@@ -183,6 +191,27 @@ bool FishHubMqttClient::publishReading(const String& payload) {
   bool ok = _client.publish(topic.c_str(), payload.c_str(), false);
   if (!ok) Serial.println("MQTT: publishReading failed");
   return ok;
+}
+
+void FishHubMqttClient::onConfig(byte* payload, unsigned int len) {
+  if (len == 0) return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, payload, len)) {
+    Serial.println("MQTT: bad JSON on config topic");
+    return;
+  }
+
+  const char* tz = doc["timezone"];
+  if (!tz || strlen(tz) == 0) {
+    Serial.println("MQTT: config message missing 'timezone' — ignored");
+    return;
+  }
+
+  nvsStore.writeTimezone(String(tz));
+  setenv("TZ", tz, 1);
+  tzset();
+  Serial.printf("MQTT: timezone set to %s\n", tz);
 }
 
 void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, unsigned int len) {

--- a/src/nvs_store.cpp
+++ b/src/nvs_store.cpp
@@ -22,6 +22,14 @@ void NVSStore::clear() {
   _prefs.clear();
 }
 
+String NVSStore::readTimezone() {
+  return get("timezone");
+}
+
+void NVSStore::writeTimezone(const String& tz) {
+  set("timezone", tz);
+}
+
 bool NVSStore::isProvisioned() {
   bool allKeys = get("wifi_ssid")     != "" &&
                  get("wifi_pass")     != "" &&

--- a/src/wifi_ntp.cpp
+++ b/src/wifi_ntp.cpp
@@ -39,6 +39,14 @@ void connectWifi() {
 
 void waitForNtp() {
   configTime(0, 0, "pool.ntp.org");
+
+  String tz = nvsStore.readTimezone();
+  if (!tz.isEmpty()) {
+    setenv("TZ", tz.c_str(), 1);
+    tzset();
+    Serial.printf("NTP: applying stored timezone %s\n", tz.c_str());
+  }
+
   Serial.println("Waiting for NTP sync...");
 
   struct tm timeinfo;


### PR DESCRIPTION
Implements issue #61. The device now subscribes to
`fishhub/<deviceId>/config` on MQTT connect. When a config message
arrives, the `timezone` field is parsed, persisted to NVS via
`NVSStore::writeTimezone()`, and applied immediately with
`setenv("TZ", …)` / `tzset()` — no reboot required.

On boot, `waitForNtp()` reads the stored timezone and applies it before
the first `localtime_r()` call so schedule evaluation always uses local
time. Devices with no timezone in NVS default to UTC.

Closes #61

https://claude.ai/code/session_01NtiWia1sBUeaYeGb3mnkHZ