### PR TITLE
Implement explicit state machine

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -1,0 +1,35 @@
+#include <Arduino.h>
+#include "button.h"
+#include "pins.h"
+#include "nvs_store.h"
+#include "provisioning.h"
+
+void checkButton()
+{
+  if (digitalRead(RESET_BUTTON_PIN) != LOW)
+    return;
+
+  Serial.println("Reset button pressed");
+  Serial.println("- 3s  => enter provisioning mode");
+  Serial.println("- 10s => clear all data");
+
+  unsigned long pressStart = millis();
+  while (digitalRead(RESET_BUTTON_PIN) == LOW)
+  {
+    Serial.printf("Held for %lu ms\n", millis() - pressStart);
+    delay(50);
+  }
+  unsigned long held = millis() - pressStart;
+
+  if (held >= 10000)
+  {
+    Serial.println("Button held 10s — clearing NVS and rebooting...");
+    nvsStore.clear();
+    ESP.restart();
+  }
+  else if (held >= 3000)
+  {
+    Serial.println("Button held 3s — entering reconfiguration mode...");
+    startProvisioning(); // never returns
+  }
+}

--- a/src/button.h
+++ b/src/button.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Reads RESET_BUTTON_PIN hold duration.
+// 3 s  → enters provisioning mode (via startProvisioning()).
+// 10 s → clears NVS and reboots.
+// Safe to call from any context, including a FreeRTOS task.
+void checkButton();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,12 +27,32 @@ static State         errorNextState  = State::CONNECT_WIFI;
 
 static const unsigned long ERROR_RETRY_DELAY_MS = 10000;
 
+static const char *stateName(State s)
+{
+  switch (s) {
+    case State::PROVISIONING:      return "PROVISIONING";
+    case State::CONNECT_WIFI:      return "CONNECT_WIFI";
+    case State::NTP_SYNC:          return "NTP_SYNC";
+    case State::NORMAL_OPERATION:  return "NORMAL_OPERATION";
+    case State::ERROR_RETRY:       return "ERROR_RETRY";
+  }
+  return "UNKNOWN";
+}
+
+static void setState(State next)
+{
+  if (next != state) {
+    Serial.printf("State: %s → %s\n", stateName(state), stateName(next));
+    state = next;
+  }
+}
+
 static void enterErrorRetry(State next, const char *reason)
 {
   Serial.printf("Error: %s — retrying in %lu s\n", reason, ERROR_RETRY_DELAY_MS / 1000);
   errorRetryUntil = millis() + ERROR_RETRY_DELAY_MS;
   errorNextState  = next;
-  state           = State::ERROR_RETRY;
+  setState(State::ERROR_RETRY);
 }
 
 // ─── normal operation helpers ─────────────────────────────────────────────────
@@ -97,7 +117,7 @@ static void runState()
 
     case State::CONNECT_WIFI:
       if (connectWifi()) {
-        state = State::NTP_SYNC;
+        setState(State::NTP_SYNC);
       } else {
         enterErrorRetry(State::CONNECT_WIFI, "Wi-Fi connection failed");
       }
@@ -105,7 +125,7 @@ static void runState()
 
     case State::NTP_SYNC:
       if (waitForNtp()) {
-        state = State::NORMAL_OPERATION;
+        setState(State::NORMAL_OPERATION);
       } else {
         enterErrorRetry(State::CONNECT_WIFI, "NTP sync failed");
       }
@@ -119,7 +139,7 @@ static void runState()
 
     case State::ERROR_RETRY:
       if (millis() >= errorRetryUntil)
-        state = errorNextState;
+        setState(errorNextState);
       break;
   }
 }
@@ -142,6 +162,7 @@ void setup()
   }
 
   state = nvsStore.isProvisioned() ? State::CONNECT_WIFI : State::PROVISIONING;
+  Serial.printf("State: initial → %s\n", stateName(state));
 }
 
 void loop()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,40 +8,39 @@
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripherals/relay_actuator.h"
+#include "button.h"
+
+// ─── state machine ────────────────────────────────────────────────────────────
+
+enum class State {
+  PROVISIONING,
+  CONNECT_WIFI,
+  NTP_SYNC,
+  NORMAL_OPERATION,
+  ERROR_RETRY,
+};
+
+static State state;
+
+static unsigned long errorRetryUntil = 0;
+static State         errorNextState  = State::CONNECT_WIFI;
+
+static const unsigned long ERROR_RETRY_DELAY_MS = 10000;
+
+static void enterErrorRetry(State next, const char *reason)
+{
+  Serial.printf("Error: %s — retrying in %lu s\n", reason, ERROR_RETRY_DELAY_MS / 1000);
+  errorRetryUntil = millis() + ERROR_RETRY_DELAY_MS;
+  errorNextState  = next;
+  state           = State::ERROR_RETRY;
+}
+
+// ─── normal operation helpers ─────────────────────────────────────────────────
 
 static PeripheralManager manager;
 static FishHubMqttClient mqttClient;
+static bool normalOperationInitDone = false;
 
-static void boot()
-{
-  Serial.begin(115200);
-  Serial.println("FishHub firmware booting...");
-  nvsStore.begin();
-  pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
-
-  Serial.println("NVS key status:");
-  for (const char *key : {"wifi_ssid", "wifi_pass", "device_id", "device_jwt",
-                          "mqtt_username", "mqtt_host", "provisioned"})
-  {
-    Serial.printf("  NVS %-14s %s\n", key,
-                  nvsStore.get(key).isEmpty() ? "MISSING" : "present");
-  }
-}
-
-static void provisioningMode()
-{
-  Serial.println("Device not fully provisioned — entering provisioning mode");
-  startProvisioning(); // never returns — reboots on success, loops on error
-}
-
-static void connectToWifi()
-{
-  connectWifi();
-  waitForNtp();
-}
-
-// Restore peripherals persisted in NVS so the device is functional
-// immediately on boot, before retained MQTT messages are re-delivered.
 static void restorePeripherals()
 {
   String json = nvsStore.get("peripherals");
@@ -70,41 +69,12 @@ static void restorePeripherals()
   }
 }
 
-static void normalOperation()
+static void initNormalOperation()
 {
   restorePeripherals();
   manager.beginAll();
   mqttClient.begin(manager);
-}
-
-static void handleButton()
-{
-  if (digitalRead(RESET_BUTTON_PIN) != LOW)
-    return;
-
-  Serial.println("Reset button pressed");
-  Serial.println("- 3s  => enter provisioning mode");
-  Serial.println("- 10s => clear all data");
-
-  unsigned long pressStart = millis();
-  while (digitalRead(RESET_BUTTON_PIN) == LOW)
-  {
-    Serial.printf("Held for %lu ms\n", millis() - pressStart);
-    delay(50);
-  }
-  unsigned long held = millis() - pressStart;
-
-  if (held >= 10000)
-  {
-    Serial.println("Button held 10s — clearing NVS and rebooting...");
-    nvsStore.clear();
-    ESP.restart();
-  }
-  else if (held >= 3000)
-  {
-    Serial.println("Button held 3s — entering reconfiguration mode...");
-    provisioningMode(); // never returns
-  }
+  normalOperationInitDone = true;
 }
 
 static void sensorTick()
@@ -116,17 +86,66 @@ static void sensorTick()
     mqttClient.publishReading(payload);
 }
 
+// ─── state dispatch ───────────────────────────────────────────────────────────
+
+static void runState()
+{
+  switch (state) {
+    case State::PROVISIONING:
+      startProvisioning(); // never returns — reboots on success
+      break;
+
+    case State::CONNECT_WIFI:
+      if (connectWifi()) {
+        state = State::NTP_SYNC;
+      } else {
+        enterErrorRetry(State::CONNECT_WIFI, "Wi-Fi connection failed");
+      }
+      break;
+
+    case State::NTP_SYNC:
+      if (waitForNtp()) {
+        state = State::NORMAL_OPERATION;
+      } else {
+        enterErrorRetry(State::CONNECT_WIFI, "NTP sync failed");
+      }
+      break;
+
+    case State::NORMAL_OPERATION:
+      if (!normalOperationInitDone)
+        initNormalOperation();
+      sensorTick();
+      break;
+
+    case State::ERROR_RETRY:
+      if (millis() >= errorRetryUntil)
+        state = errorNextState;
+      break;
+  }
+}
+
+// ─── Arduino entry points ─────────────────────────────────────────────────────
+
 void setup()
 {
-  boot();
-  if (!nvsStore.isProvisioned())
-    provisioningMode();
-  connectToWifi();
-  normalOperation();
+  Serial.begin(115200);
+  Serial.println("FishHub firmware booting...");
+  nvsStore.begin();
+  pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
+
+  Serial.println("NVS key status:");
+  for (const char *key : {"wifi_ssid", "wifi_pass", "device_id", "device_jwt",
+                          "mqtt_username", "mqtt_host", "provisioned"})
+  {
+    Serial.printf("  NVS %-14s %s\n", key,
+                  nvsStore.get(key).isEmpty() ? "MISSING" : "present");
+  }
+
+  state = nvsStore.isProvisioned() ? State::CONNECT_WIFI : State::PROVISIONING;
 }
 
 void loop()
 {
-  handleButton();
-  sensorTick();
+  checkButton();
+  runState();
 }

--- a/src/provisioning.cpp
+++ b/src/provisioning.cpp
@@ -1,5 +1,6 @@
 #include "provisioning.h"
 #include "nvs_store.h"
+#include "button.h"
 #include "config.h"
 #include <WiFi.h>
 #include <WebServer.h>
@@ -12,6 +13,15 @@
 static SemaphoreHandle_t scanMutex;
 static std::vector<String> scannedSSIDs;
 static bool scanDone = false;
+
+static void buttonTask(void *)
+{
+  for (;;)
+  {
+    checkButton();
+    delay(50);
+  }
+}
 
 static void scanTask(void *)
 {
@@ -474,7 +484,8 @@ void startProvisioning()
   WiFi.mode(WIFI_AP_STA);
   WiFi.softAP("FishHub-Setup");
 
-  xTaskCreatePinnedToCore(scanTask, "wifi_scan", 4096, nullptr, 1, nullptr, 0);
+  xTaskCreatePinnedToCore(scanTask,   "wifi_scan", 4096, nullptr, 1, nullptr, 0);
+  xTaskCreatePinnedToCore(buttonTask, "btn_check", 2048, nullptr, 1, nullptr, 0);
   Serial.printf("AP started — SSID: FishHub-Setup  IP: %s\n",
                 WiFi.softAPIP().toString().c_str());
 

--- a/src/wifi_ntp.cpp
+++ b/src/wifi_ntp.cpp
@@ -9,7 +9,7 @@ static const int WIFI_TIMEOUT_MS  = 10000;
 static const int WIFI_MAX_RETRIES = 3;
 static const int NTP_TIMEOUT_MS   = 10000;
 
-void connectWifi() {
+bool connectWifi() {
   String ssid     = nvsStore.get("wifi_ssid");
   String password = nvsStore.get("wifi_pass");
   if (ssid.isEmpty())     ssid     = WIFI_SSID;
@@ -26,18 +26,18 @@ void connectWifi() {
 
     if (WiFi.status() == WL_CONNECTED) {
       Serial.printf("Wi-Fi connected — IP: %s\n", WiFi.localIP().toString().c_str());
-      return;
+      return true;
     }
 
     WiFi.disconnect(true);
     Serial.println("Wi-Fi attempt timed out");
   }
 
-  Serial.println("Wi-Fi connection failed after 3 attempts — halting");
-  while (true) delay(1000);
+  Serial.println("Wi-Fi connection failed after 3 attempts");
+  return false;
 }
 
-void waitForNtp() {
+bool waitForNtp() {
   configTime(0, 0, "pool.ntp.org");
 
   String tz = nvsStore.readTimezone();
@@ -56,11 +56,12 @@ void waitForNtp() {
   }
 
   if (!getLocalTime(&timeinfo)) {
-    Serial.println("NTP sync failed — halting");
-    while (true) delay(1000);
+    Serial.println("NTP sync failed");
+    return false;
   }
 
   char buf[32];
   strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &timeinfo);
   Serial.printf("NTP synced: %s\n", buf);
+  return true;
 }

--- a/src/wifi_ntp.h
+++ b/src/wifi_ntp.h
@@ -1,4 +1,5 @@
 #pragma once
 
-void connectWifi();
-void waitForNtp();
+// Returns true on success, false on failure (all retries exhausted / timeout).
+bool connectWifi();
+bool waitForNtp();


### PR DESCRIPTION
## Summary

- `setup()` is now hardware-only (Serial, NVS, pins) — no blocking calls or application logic
- `loop()` dispatches on an explicit `State` enum: `PROVISIONING`, `CONNECT_WIFI`, `NTP_SYNC`, `NORMAL_OPERATION`, `ERROR_RETRY`
- `connectWifi()` and `waitForNtp()` return `bool` instead of halting; failures enter `ERROR_RETRY` and retry after 10 s
- Button hold logic extracted into `src/button.h` / `button.cpp` — single implementation called from both `loop()` and a FreeRTOS task inside `startProvisioning()`, so the 10 s factory reset works from every state including while the captive portal is blocking

Closes #56