### PR TITLE
Add currentMeasurements() and trigger evaluation in PeripheralManager

### DIFF
--- a/include/peripheral.h
+++ b/include/peripheral.h
@@ -9,6 +9,8 @@ using String = std::string;
 #endif
 
 #include <ArduinoJson.h>
+#include <map>
+#include <string>
 #include <time.h>
 
 class Peripheral {
@@ -34,6 +36,11 @@ public:
   // One-shot peripherals (feeder, doser) override to false — the MQTT client will
   // deduplicate by persisting the last processed command ID in NVS.
   virtual bool replayCommand() const { return true; }
+
+  // Populates `out` with current measurement values keyed by SenML name
+  // (e.g. "ds18b20-4/temperature"). Called each tick cycle to build the
+  // snapshot used by trigger evaluation. Default: no-op.
+  virtual void currentMeasurements(std::map<std::string, float>& out) const {}
 
   // Unique name — used as MQTT topic segment and SenML field name prefix.
   virtual const char* name() const = 0;

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -13,6 +13,7 @@ using String = std::string;
 #include <vector>
 #include <time.h>
 #include "peripheral.h"
+#include "trigger.h"
 
 struct PeripheralEntry {
   Peripheral* peripheral;
@@ -49,7 +50,17 @@ public:
   // Returns the peripheral with the given name, or nullptr if not found.
   Peripheral* find(const String& name) const;
 
+  // Adds a trigger. Ownership is transferred — removeTrigger() will delete it.
+  void     addTrigger(Trigger* t);
+
+  // Removes the trigger with the given id and deletes the object.
+  void     removeTrigger(const std::string& id);
+
+  // Returns the trigger with the given id, or nullptr if not found.
+  Trigger* findTrigger(const std::string& id) const;
+
 private:
   std::vector<PeripheralEntry> _entries;
+  std::vector<Trigger*>        _triggers;
   bool _begun = false;
 };

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -56,6 +56,17 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
     }
   }
 
+  // Trigger evaluation pass — runs regardless of whether readings were produced
+  if (!_triggers.empty()) {
+    std::map<std::string, float> values;
+    for (const auto& e : _entries) {
+      e.peripheral->currentMeasurements(values);
+    }
+    for (auto* t : _triggers) {
+      t->evaluate(values, now, *this);
+    }
+  }
+
   if (!anyData) return String{};
 
   // Prepend base record now that we know there is data
@@ -86,6 +97,27 @@ void PeripheralManager::dispatchCommand(const String& name, JsonObjectConst cmd)
 Peripheral* PeripheralManager::find(const String& name) const {
   for (auto& e : _entries) {
     if (name == e.peripheral->name()) return e.peripheral;
+  }
+  return nullptr;
+}
+
+void PeripheralManager::addTrigger(Trigger* t) {
+  _triggers.push_back(t);
+}
+
+void PeripheralManager::removeTrigger(const std::string& id) {
+  for (auto it = _triggers.begin(); it != _triggers.end(); ++it) {
+    if ((*it)->id() == id) {
+      delete *it;
+      _triggers.erase(it);
+      return;
+    }
+  }
+}
+
+Trigger* PeripheralManager::findTrigger(const std::string& id) const {
+  for (auto* t : _triggers) {
+    if (t->id() == id) return t;
   }
   return nullptr;
 }

--- a/src/peripherals/ds18b20_sensor.cpp
+++ b/src/peripherals/ds18b20_sensor.cpp
@@ -21,6 +21,10 @@ bool DS18B20Sensor::tick(time_t /*now*/) {
   return true;
 }
 
+void DS18B20Sensor::currentMeasurements(std::map<std::string, float>& out) const {
+  out[std::string(_name) + "/temperature"] = _lastTemp;
+}
+
 void DS18B20Sensor::appendSenML(JsonArray& records, time_t /*now*/) {
   JsonObject r = records.add<JsonObject>();
   String n = String(_name.c_str()) + "/temperature";

--- a/src/peripherals/ds18b20_sensor.h
+++ b/src/peripherals/ds18b20_sensor.h
@@ -17,6 +17,7 @@ public:
   uint32_t    intervalMs() const override { return _intervalMs; }
   bool        tick(time_t now) override;
   void        appendSenML(JsonArray& records, time_t now) override;
+  void        currentMeasurements(std::map<std::string, float>& out) const override;
   const char* name() const override { return _name.c_str(); }
 
 private:

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -44,6 +44,10 @@ void RelayActuator::appendSenML(JsonArray& records, time_t /*now*/) {
   src["vs"] = _lastChanged ? "change" : "heartbeat";
 }
 
+void RelayActuator::currentMeasurements(std::map<std::string, float>& out) const {
+  out[_name + "/state"] = _currentState ? 1.0f : 0.0f;
+}
+
 void RelayActuator::applyCommand(JsonObjectConst cmd) {
   const char* action = cmd["action"];
   if (!action) return;

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -21,6 +21,7 @@ public:
   uint32_t    intervalMs() const override { return 1000; }
   bool        tick(time_t now) override;
   void        appendSenML(JsonArray& records, time_t now) override;
+  void        currentMeasurements(std::map<std::string, float>& out) const override;
   void        applyCommand(JsonObjectConst cmd) override;
   const char* name() const override { return _name.c_str(); }
 

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -1,4 +1,5 @@
 #include "trigger.h"
+#include "peripheral_manager.h"
 #include <cmath>
 #include <cstring>
 
@@ -93,5 +94,5 @@ float Trigger::evalNode(JsonObjectConst node,
 
 void Trigger::applyTo(PeripheralManager& mgr) const {
   if (_targetPeripheral.empty()) return;
-  mgr.dispatchCommand(String(_targetPeripheral), _actionDoc.as<JsonObjectConst>());
+  mgr.dispatchCommand(String(_targetPeripheral.c_str()), _actionDoc.as<JsonObjectConst>());
 }

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -11,7 +11,9 @@ using String = std::string;
 #include <ArduinoJson.h>
 #include <map>
 #include <time.h>
-#include "peripheral_manager.h"
+
+// Forward declaration to avoid circular include with peripheral_manager.h
+class PeripheralManager;
 
 class Trigger {
 public:

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -1,17 +1,20 @@
 #include <unity.h>
 #include <ArduinoJson.h>
 #include <cstdlib>
+#include <map>
+#include <string>
 #include "peripheral_manager.h"
 #include "schedule.h"
 #include "../../src/peripheral_manager.cpp"
 #include "../../src/schedule.cpp"
+#include "../../src/trigger.cpp"
 
 // ── mock peripheral ──────────────────────────────────────────────────────────
 
 class MockPeripheral : public Peripheral {
 public:
-  explicit MockPeripheral(const char* n, uint32_t interval)
-    : _name(n), _interval(interval), tickCount(0), lastCmd("") {}
+  explicit MockPeripheral(const char* n, uint32_t interval, float value = 0.0f)
+    : _name(n), _interval(interval), tickCount(0), lastCmd(""), _value(value) {}
 
   void        begin() override {}
   uint32_t    intervalMs() const override { return _interval; }
@@ -32,8 +35,13 @@ public:
     lastCmd = cmd["action"].as<String>();
   }
 
+  void currentMeasurements(std::map<std::string, float>& out) const override {
+    out[std::string(_name) + "/value"] = _value;
+  }
+
   int    tickCount;
   String lastCmd;
+  float  _value;
 
 private:
   const char* _name;
@@ -274,6 +282,143 @@ void test_manager_add_after_begin_calls_begin(void) {
   mgr.remove("late");
 }
 
+// ── Trigger integration ───────────────────────────────────────────────────────
+
+static Trigger* makeTrigger(const char* id, const char* condJson,
+                             const char* target, bool enabled = true) {
+  std::string json = R"({"id":")";
+  json += id;
+  json += R"(","enabled":)";
+  json += enabled ? "true" : "false";
+  json += R"(,"target":")";
+  json += target;
+  json += R"(","cooldown_s":0,)";
+  json += R"("action":{"action":"set","value":1.0},)";
+  json += R"("condition":)";
+  json += condJson;
+  json += "}";
+
+  JsonDocument* doc = new JsonDocument();
+  deserializeJson(*doc, json.c_str());
+  Trigger* t = new Trigger();
+  t->load(doc->as<JsonObjectConst>());
+  delete doc;
+  return t;
+}
+
+void test_trigger_add_find_remove(void) {
+  PeripheralManager mgr;
+  Trigger* t = makeTrigger("t1", R"({"op":"literal","value":1})", "relay");
+  mgr.addTrigger(t);
+  TEST_ASSERT_NOT_NULL(mgr.findTrigger("t1"));
+  mgr.removeTrigger("t1");
+  TEST_ASSERT_NULL(mgr.findTrigger("t1"));
+}
+
+void test_trigger_fires_when_condition_met(void) {
+  PeripheralManager mgr;
+  // Sensor reports 15.0 — trigger fires when value < 19.0
+  MockPeripheral* sensor = new MockPeripheral("temp", 1000, 15.0f);
+  MockPeripheral* relay  = new MockPeripheral("relay", 1000);
+  mgr.add(sensor);
+  mgr.add(relay);
+  mgr.beginAll();
+
+  Trigger* t = makeTrigger("t1",
+    R"({"op":"lt","left":{"op":"value","measurement":"temp/value"},"right":{"op":"literal","value":19.0}})",
+    "relay");
+  mgr.addTrigger(t);
+
+  mgr.tickAll(1000, 1000);
+  TEST_ASSERT_EQUAL_STRING("set", relay->lastCmd.c_str());
+
+  mgr.remove("temp");
+  mgr.remove("relay");
+}
+
+void test_trigger_does_not_fire_when_condition_false(void) {
+  PeripheralManager mgr;
+  // Sensor reports 25.0 — trigger does NOT fire when value < 19.0
+  MockPeripheral* sensor = new MockPeripheral("temp", 1000, 25.0f);
+  MockPeripheral* relay  = new MockPeripheral("relay", 1000);
+  mgr.add(sensor);
+  mgr.add(relay);
+  mgr.beginAll();
+
+  Trigger* t = makeTrigger("t1",
+    R"({"op":"lt","left":{"op":"value","measurement":"temp/value"},"right":{"op":"literal","value":19.0}})",
+    "relay");
+  mgr.addTrigger(t);
+
+  mgr.tickAll(1000, 1000);
+  TEST_ASSERT_EQUAL_STRING("", relay->lastCmd.c_str());
+
+  mgr.remove("temp");
+  mgr.remove("relay");
+}
+
+void test_trigger_respects_cooldown(void) {
+  PeripheralManager mgr;
+  MockPeripheral* sensor = new MockPeripheral("temp", 1000, 15.0f);
+  MockPeripheral* relay  = new MockPeripheral("relay", 1000);
+  mgr.add(sensor);
+  mgr.add(relay);
+  mgr.beginAll();
+
+  std::string json = R"({"id":"t1","enabled":true,"target":"relay","cooldown_s":10,)"
+                     R"("action":{"action":"set","value":1.0},)"
+                     R"("condition":{"op":"lt","left":{"op":"value","measurement":"temp/value"},)"
+                     R"("right":{"op":"literal","value":19.0}}})";
+  JsonDocument doc;
+  deserializeJson(doc, json.c_str());
+  Trigger* t = new Trigger();
+  t->load(doc.as<JsonObjectConst>());
+  mgr.addTrigger(t);
+
+  // First tick at t=1 — fires
+  mgr.tickAll(1, 1000);
+  TEST_ASSERT_EQUAL_STRING("set", relay->lastCmd.c_str());
+
+  // Reset lastCmd and tick at t=5 (within 10s cooldown) — must NOT fire
+  relay->lastCmd = "";
+  mgr.tickAll(5, 2000);
+  TEST_ASSERT_EQUAL_STRING("", relay->lastCmd.c_str());
+
+  // Tick at t=12 (past cooldown) — fires again
+  mgr.tickAll(12, 3000);
+  TEST_ASSERT_EQUAL_STRING("set", relay->lastCmd.c_str());
+
+  mgr.remove("temp");
+  mgr.remove("relay");
+}
+
+void test_trigger_disabled_does_not_fire(void) {
+  PeripheralManager mgr;
+  MockPeripheral* sensor = new MockPeripheral("temp", 1000, 15.0f);
+  MockPeripheral* relay  = new MockPeripheral("relay", 1000);
+  mgr.add(sensor);
+  mgr.add(relay);
+  mgr.beginAll();
+
+  Trigger* t = makeTrigger("t1",
+    R"({"op":"lt","left":{"op":"value","measurement":"temp/value"},"right":{"op":"literal","value":19.0}})",
+    "relay", false);
+  mgr.addTrigger(t);
+
+  mgr.tickAll(1000, 1000);
+  TEST_ASSERT_EQUAL_STRING("", relay->lastCmd.c_str());
+
+  mgr.remove("temp");
+  mgr.remove("relay");
+}
+
+void test_current_measurements_populates_map(void) {
+  MockPeripheral p("sensor", 1000, 42.5f);
+  std::map<std::string, float> values;
+  p.currentMeasurements(values);
+  TEST_ASSERT_EQUAL_FLOAT(42.5f, values["sensor/value"]);
+}
+
 // ── entry point ──────────────────────────────────────────────────────────────
 
 void setUp(void) {}
@@ -306,5 +451,11 @@ int main(void) {
   RUN_TEST(test_manager_remove);
   RUN_TEST(test_manager_has);
   RUN_TEST(test_manager_add_after_begin_calls_begin);
+  RUN_TEST(test_trigger_add_find_remove);
+  RUN_TEST(test_trigger_fires_when_condition_met);
+  RUN_TEST(test_trigger_does_not_fire_when_condition_false);
+  RUN_TEST(test_trigger_respects_cooldown);
+  RUN_TEST(test_trigger_disabled_does_not_fire);
+  RUN_TEST(test_current_measurements_populates_map);
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- Adds `currentMeasurements(out)` default no-op to the `Peripheral` interface, implemented in `DS18B20Sensor` (emits `<name>/temperature`) and `RelayActuator` (emits `<name>/state`)
- Extends `PeripheralManager` with `addTrigger` / `removeTrigger` / `findTrigger` and a second evaluation pass in `tickAll` that builds a measurement snapshot and calls `t->evaluate()` on each registered trigger
- Fixes circular include between `trigger.h` and `peripheral_manager.h` using a forward declaration
- 6 new integration tests in `test_native` covering trigger wiring, condition evaluation, cooldown, and disabled state

Closes #66

## Test plan

- [x] `pio test -e native` — 61/61 passing
- [x] `pio run` — ESP32 build clean