### PR TITLE
Add MQTT routing for trigger messages

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -16,6 +16,7 @@ private:
   void onMessage(char* topic, byte* payload, unsigned int len);
   void onConfig(byte* payload, unsigned int len);
   void onPeripheralConfig(const String& name, byte* payload, unsigned int len);
+  void onTriggerConfig(const String& id, byte* payload, unsigned int len);
 
   WiFiClientSecure   _tlsClient;
   PubSubClient       _client;

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "peripherals/relay_actuator.h"
 #include "peripherals/ds18b20_sensor.h"
+#include "trigger.h"
 #include <ArduinoJson.h>
 
 static const unsigned long RECONNECT_INTERVAL_MS = 5000;
@@ -100,10 +101,12 @@ void FishHubMqttClient::connect() {
   String cmdTopic         = "fishhub/" + _deviceId + "/commands/#";
   String peripheralsTopic = "fishhub/" + _deviceId + "/peripherals/#";
   String configTopic      = "fishhub/" + _deviceId + "/config";
+  String triggersTopic    = "fishhub/" + _deviceId + "/triggers/#";
   _client.subscribe(cmdTopic.c_str());
   _client.subscribe(peripheralsTopic.c_str());
   _client.subscribe(configTopic.c_str());
-  Serial.printf("MQTT: connected, subscribed to commands, peripherals and config topics\n");
+  _client.subscribe(triggersTopic.c_str());
+  Serial.printf("MQTT: connected, subscribed to commands, peripherals, config and triggers topics\n");
 }
 
 void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) {
@@ -126,6 +129,11 @@ void FishHubMqttClient::onMessage(char* topic, byte* payload, unsigned int len) 
 
   if (segment == "peripherals") {
     onPeripheralConfig(name, payload, len);
+    return;
+  }
+
+  if (segment == "triggers") {
+    onTriggerConfig(name, payload, len);
     return;
   }
 
@@ -256,4 +264,39 @@ void FishHubMqttClient::onPeripheralConfig(const String& name, byte* payload, un
     }
     savePeripheralsToNVS(_manager);
   }
+}
+
+void FishHubMqttClient::onTriggerConfig(const String& id, byte* payload, unsigned int len) {
+  if (len == 0) return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, payload, len)) {
+    Serial.printf("MQTT: bad JSON on triggers/%s\n", id.c_str());
+    return;
+  }
+
+  const char* op = doc["op"];
+  if (!op) return;
+
+  if (strcmp(op, "delete") == 0) {
+    _manager->removeTrigger(id.c_str());
+    Serial.printf("MQTT: removed trigger '%s'\n", id.c_str());
+    return;
+  }
+
+  if (strcmp(op, "upsert") == 0) {
+    Trigger* existing = _manager->findTrigger(id.c_str());
+    if (existing) {
+      existing->load(doc.as<JsonObjectConst>());
+      Serial.printf("MQTT: updated trigger '%s'\n", id.c_str());
+    } else {
+      Trigger* t = new Trigger();
+      t->load(doc.as<JsonObjectConst>());
+      _manager->addTrigger(t);
+      Serial.printf("MQTT: registered trigger '%s'\n", id.c_str());
+    }
+    return;
+  }
+
+  Serial.printf("MQTT: unknown op '%s' on triggers/%s\n", op, id.c_str());
 }


### PR DESCRIPTION
## Summary

- Subscribes to `fishhub/{device_id}/triggers/#` on MQTT connect
- Routes inbound trigger messages to `onTriggerConfig` — mirrors the existing `onPeripheralConfig` pattern
- `op:upsert` creates a new `Trigger` (heap-allocated, owned by `PeripheralManager`) or updates an existing one in place via `load()`
- `op:delete` calls `removeTrigger()` which deletes the object
- Empty payloads ignored — the server sends one as housekeeping after the `op:delete` payload

## Test plan

- [x] `pio run` — ESP32 build clean
- [x] `pio test -e native` — 61/61 passing

Closes #67