### PR TITLE
Persist triggers to NVS across reboots

### DIFF
--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -59,6 +59,9 @@ public:
   // Returns the trigger with the given id, or nullptr if not found.
   Trigger* findTrigger(const std::string& id) const;
 
+  // Iterates all triggers, calling fn(trigger) for each.
+  void forEachTrigger(std::function<void(Trigger*)> fn) const;
+
 private:
   std::vector<PeripheralEntry> _entries;
   std::vector<Trigger*>        _triggers;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripherals/relay_actuator.h"
+#include "trigger.h"
 #include "button.h"
 
 // ─── state machine ────────────────────────────────────────────────────────────
@@ -89,9 +90,43 @@ static void restorePeripherals()
   }
 }
 
+static void restoreTriggers()
+{
+  String idxJson = nvsStore.get("trig_index");
+  if (idxJson.isEmpty()) return;
+
+  JsonDocument idxDoc;
+  if (deserializeJson(idxDoc, idxJson)) {
+    Serial.println("NVS: failed to parse trig_index — skipping trigger restore");
+    return;
+  }
+
+  for (JsonVariant v : idxDoc.as<JsonArray>()) {
+    String prefix = v.as<String>();
+    String key    = String("tr_") + prefix;
+    String json   = nvsStore.get(key.c_str());
+    if (json.isEmpty()) continue;
+
+    JsonDocument doc;
+    if (deserializeJson(doc, json)) {
+      Serial.printf("NVS: failed to parse trigger '%s' — skipping\n", prefix.c_str());
+      continue;
+    }
+
+    Trigger* t = new Trigger();
+    if (t->load(doc.as<JsonObjectConst>())) {
+      manager.addTrigger(t);
+      Serial.printf("NVS: restored trigger '%s'\n", t->id().c_str());
+    } else {
+      delete t;
+    }
+  }
+}
+
 static void initNormalOperation()
 {
   restorePeripherals();
+  restoreTriggers();
   manager.beginAll();
   mqttClient.begin(manager);
   normalOperationInitDone = true;

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -190,6 +190,54 @@ static void savePeripheralsToNVS(PeripheralManager* mgr) {
   nvsStore.set("peripherals", json);
 }
 
+// Returns "tr_" + first 10 chars of trigger id — fits the 15-char NVS key limit.
+static String triggerNvsKey(const std::string& id) {
+  return String("tr_") + id.substr(0, 10).c_str();
+}
+
+static void saveTriggerToNVS(Trigger* t) {
+  JsonDocument doc;
+  t->serializeTo(doc.as<JsonObject>());
+  String json;
+  serializeJson(doc, json);
+  nvsStore.set(triggerNvsKey(t->id()).c_str(), json);
+
+  String idxJson = nvsStore.get("trig_index");
+  JsonDocument idxDoc;
+  if (idxJson.isEmpty() || deserializeJson(idxDoc, idxJson)) {
+    idxDoc.to<JsonArray>();
+  }
+  JsonArray idx    = idxDoc.as<JsonArray>();
+  String    prefix = String(t->id().substr(0, 10).c_str());
+  for (JsonVariant v : idx) {
+    if (v.as<String>() == prefix) return;
+  }
+  idx.add(prefix);
+  String newIdx;
+  serializeJson(idxDoc, newIdx);
+  nvsStore.set("trig_index", newIdx);
+}
+
+static void removeTriggerFromNVS(const String& id) {
+  std::string sid = id.c_str();
+  nvsStore.remove(triggerNvsKey(sid).c_str());
+
+  String idxJson = nvsStore.get("trig_index");
+  if (idxJson.isEmpty()) return;
+  JsonDocument idxDoc;
+  if (deserializeJson(idxDoc, idxJson)) return;
+
+  String       prefix = String(sid.substr(0, 10).c_str());
+  JsonDocument newDoc;
+  JsonArray    dst    = newDoc.to<JsonArray>();
+  for (JsonVariant v : idxDoc.as<JsonArray>()) {
+    if (v.as<String>() != prefix) dst.add(v);
+  }
+  String newIdx;
+  serializeJson(newDoc, newIdx);
+  nvsStore.set("trig_index", newIdx);
+}
+
 bool FishHubMqttClient::publishReading(const String& payload) {
   if (!_client.connected()) {
     Serial.println("MQTT: not connected — skipping publish");
@@ -280,6 +328,7 @@ void FishHubMqttClient::onTriggerConfig(const String& id, byte* payload, unsigne
 
   if (strcmp(op, "delete") == 0) {
     _manager->removeTrigger(id.c_str());
+    removeTriggerFromNVS(id);
     Serial.printf("MQTT: removed trigger '%s'\n", id.c_str());
     return;
   }
@@ -295,6 +344,7 @@ void FishHubMqttClient::onTriggerConfig(const String& id, byte* payload, unsigne
       _manager->addTrigger(t);
       Serial.printf("MQTT: registered trigger '%s'\n", id.c_str());
     }
+    saveTriggerToNVS(_manager->findTrigger(id.c_str()));
     return;
   }
 

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -121,3 +121,7 @@ Trigger* PeripheralManager::findTrigger(const std::string& id) const {
   }
   return nullptr;
 }
+
+void PeripheralManager::forEachTrigger(std::function<void(Trigger*)> fn) const {
+  for (auto* t : _triggers) fn(t);
+}

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -92,6 +92,16 @@ float Trigger::evalNode(JsonObjectConst node,
   return 0.0f;
 }
 
+void Trigger::serializeTo(JsonObject out) const {
+  out["op"]         = "upsert";
+  out["id"]         = _id.c_str();
+  out["enabled"]    = _enabled;
+  out["target"]     = _targetPeripheral.c_str();
+  out["cooldown_s"] = _cooldownS;
+  out["condition"]  = _condDoc.as<JsonObjectConst>();
+  out["action"]     = _actionDoc.as<JsonObjectConst>();
+}
+
 void Trigger::applyTo(PeripheralManager& mgr) const {
   if (_targetPeripheral.empty()) return;
   mgr.dispatchCommand(String(_targetPeripheral.c_str()), _actionDoc.as<JsonObjectConst>());

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -20,6 +20,7 @@ public:
   bool load(JsonObjectConst json);
   bool evaluate(const std::map<std::string, float>& values, time_t now,
                 PeripheralManager& mgr);
+  void serializeTo(JsonObject out) const;
   const std::string& id() const { return _id; }
   bool enabled() const { return _enabled; }
 


### PR DESCRIPTION
## Summary

- Each trigger is persisted under NVS key `tr_<first-10-chars-of-uuid>` (13 chars — fits the 15-char `Preferences` limit)
- A `trig_index` key stores a JSON array of 10-char prefixes for enumeration on restore (Preferences has no key-listing API)
- `restoreTriggers()` is called from `initNormalOperation()` before `mqttClient.begin()`, so all persisted triggers are active before the MQTT reconnect window
- `Trigger::serializeTo(JsonObject)` added to re-serialise trigger state back to the upsert payload format
- `PeripheralManager::forEachTrigger()` added for completeness (mirrors `forEach` for peripherals)

## Test plan

- [x] `pio run` — clean build
- [x] `pio test -e native` — 61/61 tests passing

Closes #68