### PR TITLE
Triggers: add Triggers section to docs/peripherals.md

### DIFF
--- a/docs/peripherals.md
+++ b/docs/peripherals.md
@@ -142,6 +142,105 @@ Manages the TLS MQTT connection and routes inbound commands to `PeripheralManage
 
 ---
 
+## Triggers (`src/trigger.h/.cpp`)
+
+A trigger is a server-pushed automation rule that fires when a condition evaluated against the latest sensor readings becomes true. It has no relationship to the `Peripheral` interface — it sits alongside peripherals and is driven by `PeripheralManager::evaluateTriggers()` after each sensor tick.
+
+### `Trigger` class API
+
+```cpp
+bool load(JsonObjectConst json);
+bool evaluate(const std::map<std::string, float>& values, time_t now, PeripheralManager& mgr);
+void serializeTo(JsonObject out) const;
+const std::string& id() const;
+bool enabled() const;
+```
+
+- `load(json)` — populates all fields from the MQTT payload; returns `false` if `id` is missing.
+- `evaluate(values, now, mgr)` — evaluates the condition tree against the current sensor readings. If the result is truthy and the cooldown has elapsed, calls `mgr.dispatchCommand()` on the target peripheral and updates `_lastFiredAt`. Returns `true` when the action was fired.
+- `serializeTo(out)` — writes the trigger back to a JSON object in the same shape as the MQTT upsert payload; used by NVS persistence.
+
+### Condition expression tree
+
+The `condition` field is a recursive JSON expression tree. Every node has an `"op"` field:
+
+| `op` | Children | Meaning |
+|---|---|---|
+| `"value"` | `"measurement"` (string) | Reads the named sensor value from the current readings map |
+| `"literal"` | `"value"` (number) | Constant number |
+| `"and"` | `"left"`, `"right"` | Logical AND (short-circuits) |
+| `"or"` | `"left"`, `"right"` | Logical OR (short-circuits) |
+| `"not"` | `"left"` | Logical NOT |
+| `"lt"`, `"lte"`, `"gt"`, `"gte"`, `"eq"` | `"left"`, `"right"` | Numeric comparison — returns 1.0 or 0.0 |
+| `"add"`, `"sub"`, `"mul"`, `"div"` | `"left"`, `"right"` | Arithmetic |
+
+The evaluator returns a `float`; any non-zero, non-NaN result is truthy. An unknown `op` returns `0.0`. Division by zero logs a warning and returns `0.0`.
+
+**Full example** — fire when temperature is below 19 °C and the heater relay is off:
+
+```json
+{
+  "op": "and",
+  "left": {
+    "op": "lt",
+    "left":  { "op": "value",   "measurement": "ds18b20-4/temperature" },
+    "right": { "op": "literal", "value": 19 }
+  },
+  "right": {
+    "op": "eq",
+    "left":  { "op": "value",   "measurement": "relay-5/state" },
+    "right": { "op": "literal", "value": 0 }
+  }
+}
+```
+
+### MQTT protocol
+
+**Topic:** `fishhub/<device_id>/triggers/<trigger_id>` (retained)
+
+The firmware subscribes to `fishhub/<device_id>/triggers/#`. The last topic segment is the trigger ID.
+
+**Empty payloads are silently ignored** — the broker delivers an empty retained message when a retained topic is cleared; treating it as a delete would cause spurious removals on reconnect.
+
+**Upsert** (create or replace):
+```json
+{
+  "op": "upsert",
+  "id": "a1b2c3d4-...",
+  "enabled": true,
+  "target": "relay-5",
+  "cooldown_s": 60,
+  "condition": { ... },
+  "action": { "action": "set", "value": 1 }
+}
+```
+
+**Delete:**
+```json
+{ "op": "delete" }
+```
+
+Any other `op` value is logged and ignored.
+
+### NVS persistence
+
+Triggers are persisted to NVS so they survive power cycles without waiting for the broker to re-deliver retained messages.
+
+| NVS key | Content |
+|---|---|
+| `trig_index` | JSON array of 10-char ID prefixes, e.g. `["a1b2c3d4e5","f6g7h8i9j0"]` |
+| `tr_<prefix>` | Full trigger JSON in upsert payload shape |
+
+The key format `tr_<first-10-chars-of-id>` is 13 characters and fits within the 15-character `Preferences` key limit. Because `Preferences` has no key-listing API, `trig_index` acts as an enumeration index.
+
+**On upsert:** the trigger is serialised and written under its NVS key; its prefix is appended to `trig_index` if not already present.
+
+**On delete:** the NVS key is removed and the prefix is removed from `trig_index`.
+
+**On boot** (`restoreTriggers()` in `src/main.cpp`): `trig_index` is read, each prefix is used to load the corresponding key, and each successfully parsed trigger is added to `PeripheralManager` before `FishHubMqttClient::begin()` is called. The theoretical limit is roughly 50 triggers before NVS space becomes a concern.
+
+---
+
 ## Adding a new peripheral
 
 1. Create `src/peripherals/my_peripheral.h` and `my_peripheral.cpp` implementing `Peripheral`.


### PR DESCRIPTION
## Summary

- Documents the `Trigger` class API (`load`, `evaluate`, `serializeTo`)
- Documents the JSON expression tree wire format with a complete example and operator reference table
- Documents the MQTT topic convention and `upsert`/`delete` protocol, including why empty payloads are ignored
- Documents NVS persistence: key format (`tr_<10-char-prefix>`), `trig_index` enumeration index, boot restore flow, and the ~50-trigger limit

## Test plan

- [ ] Review doc for accuracy against `src/trigger.cpp` and `src/mqtt_client.cpp`
- [ ] Confirm NVS key format matches `triggerNvsKey()` helper

Closes #69