### PR TITLE
fix: correct trigger evaluation and target_peripheral field name

### DIFF
--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -45,6 +45,18 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
   JsonDocument doc;
   JsonArray records = doc.to<JsonArray>();
 
+  // Trigger evaluation runs first so any command it dispatches is applied
+  // before the peripheral tick loop drives the hardware.
+  if (!_triggers.empty()) {
+    std::map<std::string, float> values;
+    for (const auto& e : _entries) {
+      e.peripheral->currentMeasurements(values);
+    }
+    for (auto* t : _triggers) {
+      t->evaluate(values, now, *this);
+    }
+  }
+
   bool anyData = false;
   for (auto& e : _entries) {
     if (nowMs - e.lastTickedAt >= e.peripheral->intervalMs()) {
@@ -53,17 +65,6 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
         e.peripheral->appendSenML(records, now);
         anyData = true;
       }
-    }
-  }
-
-  // Trigger evaluation pass — runs regardless of whether readings were produced
-  if (!_triggers.empty()) {
-    std::map<std::string, float> values;
-    for (const auto& e : _entries) {
-      e.peripheral->currentMeasurements(values);
-    }
-    for (auto* t : _triggers) {
-      t->evaluate(values, now, *this);
     }
   }
 
@@ -88,10 +89,17 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
 void PeripheralManager::dispatchCommand(const String& name, JsonObjectConst cmd) {
   for (auto& e : _entries) {
     if (name == e.peripheral->name()) {
+#ifdef ARDUINO
+      String dbg; serializeJson(cmd, dbg);
+      Serial.printf("DBG  [dispatch]: -> '%s' cmd=%s\n", name.c_str(), dbg.c_str());
+#endif
       e.peripheral->applyCommand(cmd);
       return;
     }
   }
+#ifdef ARDUINO
+  Serial.printf("WARN [dispatch]: no peripheral named '%s'\n", name.c_str());
+#endif
 }
 
 Peripheral* PeripheralManager::find(const String& name) const {

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -50,6 +50,8 @@ void RelayActuator::currentMeasurements(std::map<std::string, float>& out) const
 
 void RelayActuator::applyCommand(JsonObjectConst cmd) {
   const char* action = cmd["action"];
+  Serial.printf("DBG  [relay '%s']: applyCommand action='%s'\n",
+                _name.c_str(), action ? action : "<null>");
   if (!action) return;
 
   if (strcmp(action, "set") == 0) {

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -3,19 +3,24 @@
 #include <cmath>
 #include <cstring>
 
+#define TRIG_LOG_INTERVAL 10000
+
 #ifdef ARDUINO
 #define TRIG_WARN(fmt, ...) Serial.printf("WARN [trigger]: " fmt "\n", ##__VA_ARGS__)
+#define TRIG_DBG(fmt, ...) Serial.printf("DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
 #else
 #include <cstdio>
 #define TRIG_WARN(fmt, ...) fprintf(stderr, "WARN [trigger]: " fmt "\n", ##__VA_ARGS__)
+#define TRIG_DBG(fmt, ...) fprintf(stderr, "DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
 #endif
 
-bool Trigger::load(JsonObjectConst json) {
-  _id               = json["id"] | "";
-  _enabled          = json["enabled"] | false;
-  _targetPeripheral = json["target"] | "";
-  _cooldownS        = json["cooldown_s"] | 60u;
-  _lastFiredAt      = 0;
+bool Trigger::load(JsonObjectConst json)
+{
+  _id = json["id"] | "";
+  _enabled = json["enabled"] | false;
+  _targetPeripheral = json["target_peripheral"] | "";
+  _cooldownS = json["cooldown_s"] | 60u;
+  _lastFiredAt = 0;
 
   _condDoc.set(json["condition"]);
   _actionDoc.set(json["action"]);
@@ -23,86 +28,171 @@ bool Trigger::load(JsonObjectConst json) {
   return !_id.empty();
 }
 
-bool Trigger::evaluate(const std::map<std::string, float>& values, time_t now,
-                       PeripheralManager& mgr) {
-  if (!_enabled) return false;
+bool Trigger::evaluate(const std::map<std::string, float> &values, time_t now,
+                       PeripheralManager &mgr)
+{
+  if (!_enabled)
+    return false;
 
-  float result = evalNode(_condDoc.as<JsonObjectConst>(), values);
-  if (result == 0.0f || std::isnan(result)) return false;
+  bool periodic = (++_evalCount % TRIG_LOG_INTERVAL == 0);
 
-  if (_lastFiredAt != 0 && (now - _lastFiredAt) < (time_t)_cooldownS) return false;
+  float result = evalNode(_condDoc.as<JsonObjectConst>(), values, periodic);
 
+  if (result == 0.0f || std::isnan(result))
+  {
+    if (periodic)
+      TRIG_DBG("'%s' condition false (tick %lu)", _id.c_str(), (unsigned long)_evalCount);
+    return false;
+  }
+
+  if (_lastFiredAt != 0 && (now - _lastFiredAt) < (time_t)_cooldownS)
+  {
+    if (periodic)
+      TRIG_DBG("'%s' condition true but in cooldown (%lus remaining)",
+               _id.c_str(), (unsigned long)(_cooldownS - (now - _lastFiredAt)));
+    return false;
+  }
+
+  TRIG_DBG("'%s' FIRING -> '%s' (tick %lu)", _id.c_str(), _targetPeripheral.c_str(),
+           (unsigned long)_evalCount);
   applyTo(mgr);
   _lastFiredAt = now;
   return true;
 }
 
 float Trigger::evalNode(JsonObjectConst node,
-                        const std::map<std::string, float>& values) const {
-  const char* op = node["op"] | "";
+                        const std::map<std::string, float> &values, bool log) const
+{
+  const char *op = node["op"] | "";
 
-  if (strcmp(op, "value") == 0) {
-    const char* name = node["measurement"] | "";
+  if (strcmp(op, "value") == 0)
+  {
+    const char *name = node["measurement"] | "";
     auto it = values.find(name);
-    return (it != values.end()) ? it->second : NAN;
+    float v = (it != values.end()) ? it->second : NAN;
+    if (log)
+      TRIG_DBG("    value('%s') = %.4f", name, v);
+    return v;
   }
 
-  if (strcmp(op, "literal") == 0) {
-    return node["value"] | 0.0f;
+  if (strcmp(op, "literal") == 0)
+  {
+    float v = node["value"] | 0.0f;
+    if (log)
+      TRIG_DBG("    literal = %.4f", v);
+    return v;
   }
 
-  if (strcmp(op, "not") == 0) {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values);
-    return (l == 0.0f || std::isnan(l)) ? 1.0f : 0.0f;
+  if (strcmp(op, "not") == 0)
+  {
+    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+    float v = (l == 0.0f || std::isnan(l)) ? 1.0f : 0.0f;
+    if (log)
+      TRIG_DBG("    not(%.4f) = %.4f", l, v);
+    return v;
   }
 
-  if (strcmp(op, "and") == 0) {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values);
-    if (l == 0.0f || std::isnan(l)) return 0.0f;
-    float r = evalNode(node["right"].as<JsonObjectConst>(), values);
-    return (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+  if (strcmp(op, "and") == 0)
+  {
+    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+    if (l == 0.0f || std::isnan(l))
+    {
+      if (log)
+        TRIG_DBG("    and: left=%.4f => short-circuit false", l);
+      return 0.0f;
+    }
+    float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
+    float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+    if (log)
+      TRIG_DBG("    and(%.4f, %.4f) = %.4f", l, r, v);
+    return v;
   }
 
-  if (strcmp(op, "or") == 0) {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values);
-    if (l != 0.0f && !std::isnan(l)) return 1.0f;
-    float r = evalNode(node["right"].as<JsonObjectConst>(), values);
-    return (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+  if (strcmp(op, "or") == 0)
+  {
+    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+    if (l != 0.0f && !std::isnan(l))
+    {
+      if (log)
+        TRIG_DBG("    or: left=%.4f => short-circuit true", l);
+      return 1.0f;
+    }
+    float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
+    float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+    if (log)
+      TRIG_DBG("    or(%.4f, %.4f) = %.4f", l, r, v);
+    return v;
   }
 
-  float l = evalNode(node["left"].as<JsonObjectConst>(), values);
-  float r = evalNode(node["right"].as<JsonObjectConst>(), values);
+  float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+  float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
+  float v = 0.0f;
 
-  if (strcmp(op, "add") == 0) return l + r;
-  if (strcmp(op, "sub") == 0) return l - r;
-  if (strcmp(op, "mul") == 0) return l * r;
-  if (strcmp(op, "div") == 0) {
-    if (r == 0.0f) {
+  if (strcmp(op, "add") == 0)
+  {
+    v = l + r;
+  }
+  else if (strcmp(op, "sub") == 0)
+  {
+    v = l - r;
+  }
+  else if (strcmp(op, "mul") == 0)
+  {
+    v = l * r;
+  }
+  else if (strcmp(op, "div") == 0)
+  {
+    if (r == 0.0f)
+    {
       TRIG_WARN("division by zero in trigger '%s'", _id.c_str());
       return 0.0f;
     }
-    return l / r;
+    v = l / r;
   }
-  if (strcmp(op, "lt")  == 0) return (l <  r) ? 1.0f : 0.0f;
-  if (strcmp(op, "lte") == 0) return (l <= r) ? 1.0f : 0.0f;
-  if (strcmp(op, "gt")  == 0) return (l >  r) ? 1.0f : 0.0f;
-  if (strcmp(op, "gte") == 0) return (l >= r) ? 1.0f : 0.0f;
-  if (strcmp(op, "eq")  == 0) return (l == r) ? 1.0f : 0.0f;
+  else if (strcmp(op, "lt") == 0)
+  {
+    v = (l < r) ? 1.0f : 0.0f;
+  }
+  else if (strcmp(op, "lte") == 0)
+  {
+    v = (l <= r) ? 1.0f : 0.0f;
+  }
+  else if (strcmp(op, "gt") == 0)
+  {
+    v = (l > r) ? 1.0f : 0.0f;
+  }
+  else if (strcmp(op, "gte") == 0)
+  {
+    v = (l >= r) ? 1.0f : 0.0f;
+  }
+  else if (strcmp(op, "eq") == 0)
+  {
+    v = (l == r) ? 1.0f : 0.0f;
+  }
+  else
+  {
+    TRIG_WARN("unknown op '%s' in trigger '%s'", op, _id.c_str());
+  }
 
-  return 0.0f;
+  if (log)
+    TRIG_DBG("    %s(%.4f, %.4f) = %.4f", op, l, r, v);
+  return v;
 }
 
-void Trigger::serializeTo(JsonObject out) const {
-  out["op"]         = "upsert";
-  out["id"]         = _id.c_str();
-  out["enabled"]    = _enabled;
-  out["target"]     = _targetPeripheral.c_str();
+void Trigger::serializeTo(JsonObject out) const
+{
+  out["op"] = "upsert";
+  out["id"] = _id.c_str();
+  out["enabled"] = _enabled;
+  out["target_peripheral"] = _targetPeripheral.c_str();
   out["cooldown_s"] = _cooldownS;
-  out["condition"]  = _condDoc.as<JsonObjectConst>();
-  out["action"]     = _actionDoc.as<JsonObjectConst>();
+  out["condition"] = _condDoc.as<JsonObjectConst>();
+  out["action"] = _actionDoc.as<JsonObjectConst>();
 }
 
-void Trigger::applyTo(PeripheralManager& mgr) const {
-  if (_targetPeripheral.empty()) return;
+void Trigger::applyTo(PeripheralManager &mgr) const
+{
+  if (_targetPeripheral.empty())
+    return;
   mgr.dispatchCommand(String(_targetPeripheral.c_str()), _actionDoc.as<JsonObjectConst>());
 }

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -26,7 +26,7 @@ public:
 
 private:
   float evalNode(JsonObjectConst node,
-                 const std::map<std::string, float>& values) const;
+                 const std::map<std::string, float>& values, bool log) const;
   void  applyTo(PeripheralManager& mgr) const;
 
   std::string  _id;
@@ -34,6 +34,7 @@ private:
   JsonDocument _condDoc;
   std::string  _targetPeripheral;
   JsonDocument _actionDoc;
-  uint32_t     _cooldownS   = 60;
-  time_t       _lastFiredAt = 0;
+  uint32_t     _cooldownS    = 60;
+  time_t       _lastFiredAt  = 0;
+  uint32_t     _evalCount    = 0;
 };

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -290,7 +290,7 @@ static Trigger* makeTrigger(const char* id, const char* condJson,
   json += id;
   json += R"(","enabled":)";
   json += enabled ? "true" : "false";
-  json += R"(,"target":")";
+  json += R"(,"target_peripheral":")";
   json += target;
   json += R"(","cooldown_s":0,)";
   json += R"("action":{"action":"set","value":1.0},)";
@@ -365,7 +365,7 @@ void test_trigger_respects_cooldown(void) {
   mgr.add(relay);
   mgr.beginAll();
 
-  std::string json = R"({"id":"t1","enabled":true,"target":"relay","cooldown_s":10,)"
+  std::string json = R"({"id":"t1","enabled":true,"target_peripheral":"relay","cooldown_s":10,)"
                      R"("action":{"action":"set","value":1.0},)"
                      R"("condition":{"op":"lt","left":{"op":"value","measurement":"temp/value"},)"
                      R"("right":{"op":"literal","value":19.0}}})";


### PR DESCRIPTION
## Summary

- `Trigger::load` was reading `json["target"]` but the wire format uses `"target_peripheral"`, causing `_targetPeripheral` to always be empty and `applyTo()` to silently no-op on every fire
- `serializeTo` was also emitting `"target"` — fixed for round-trip consistency
- Trigger evaluation was running *after* the peripheral tick loop in `tickAll`, so commands dispatched by a firing trigger weren't applied until the next cycle; moved evaluation before the tick loop

## Debug logging added

- Throttled node-level traces and condition result every `TRIG_LOG_INTERVAL` (10 000) ticks
- Cooldown state also throttled to the same interval
- Fire event and `dispatchCommand` always log (unconditional — always actionable)
- `RelayActuator::applyCommand` logs the parsed action
- `dispatchCommand` warns when no peripheral matches the target name

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)