### PR TITLE
Rename peripheral command field from action to command

### DIFF
--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -49,7 +49,7 @@ void RelayActuator::currentMeasurements(std::map<std::string, float>& out) const
 }
 
 void RelayActuator::applyCommand(JsonObjectConst cmd) {
-  const char* action = cmd["action"];
+  const char* action = cmd["command"];
   Serial.printf("DBG  [relay '%s']: applyCommand action='%s'\n",
                 _name.c_str(), action ? action : "<null>");
   if (!action) return;

--- a/test/test_relay_actuator/test_relay_actuator.cpp
+++ b/test/test_relay_actuator/test_relay_actuator.cpp
@@ -25,8 +25,8 @@ static void tickAndAppend(RelayActuator& relay, bool triggerChange,
   if (triggerChange) {
     // set with a value implicitly enters Manual mode and flips state ON.
     JsonDocument cmd;
-    cmd["action"] = "set";
-    cmd["value"]  = 1.0f;
+    cmd["command"] = "set";
+    cmd["value"]   = 1.0f;
     relay.applyCommand(cmd.as<JsonObjectConst>());
   }
 
@@ -45,8 +45,8 @@ void test_state_change_emits_change_source(void) {
 
   // set with a value implicitly enters Manual mode and flips state ON.
   JsonDocument cmd;
-  cmd["action"] = "set";
-  cmd["value"]  = 1.0f;
+  cmd["command"] = "set";
+  cmd["value"]   = 1.0f;
   relay.applyCommand(cmd.as<JsonObjectConst>());
 
   time_t t = T0 + ACTUATOR_HEARTBEAT_S;


### PR DESCRIPTION
## Summary

- Renames `cmd["action"]` → `cmd["command"]` in `relay_actuator.cpp` so trigger-fired and direct commands both use the same field name
- Updates firmware native tests to use `"command"` key
- Clarifies the naming convention: `action` = a trigger action (e.g. `peripheral_action`); `command` = the verb sent to a peripheral (set, schedule, set_mode)

## Test plan

- [x] All 65 native tests pass (`pio test -e native`)
- [ ] Flash and verify relay toggles on trigger fire end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)