### PR TITLE
Update relay log to say command instead of action

### DIFF
--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -50,7 +50,7 @@ void RelayActuator::currentMeasurements(std::map<std::string, float>& out) const
 
 void RelayActuator::applyCommand(JsonObjectConst cmd) {
   const char* action = cmd["command"];
-  Serial.printf("DBG  [relay '%s']: applyCommand action='%s'\n",
+  Serial.printf("DBG  [relay '%s']: applyCommand command='%s'\n",
                 _name.c_str(), action ? action : "<null>");
   if (!action) return;
 


### PR DESCRIPTION
## Summary

- Fixes leftover `action=` label in the `applyCommand` Serial log → `command=`

Follow-up to #80.

## Test plan

- [x] All 65 native tests pass (`pio test -e native`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)