### PR TITLE
Publish trigger_event on fire with in-memory queue

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -4,27 +4,30 @@
 #include <WiFiClientSecure.h>
 #include <PubSubClient.h>
 #include "peripheral_manager.h"
+#include "../src/trigger_event_queue.h"
 
 class FishHubMqttClient {
 public:
-  void begin(PeripheralManager& manager);
+  void begin(PeripheralManager& manager, TriggerEventQueue& eventQueue);
   void loop();
   bool publishReading(const String& payload);
 
 private:
   void connect();
+  void drainEventQueue();
   void onMessage(char* topic, byte* payload, unsigned int len);
   void onConfig(byte* payload, unsigned int len);
   void onPeripheralConfig(const String& name, byte* payload, unsigned int len);
   void onTriggerConfig(const String& id, byte* payload, unsigned int len);
 
-  WiFiClientSecure   _tlsClient;
-  PubSubClient       _client;
-  PeripheralManager* _manager = nullptr;
-  String             _deviceId;
-  String             _mqttUsername;
-  String             _mqttPassword;
-  String             _mqttHost;
-  uint16_t           _mqttPort = 8883;
-  unsigned long      _lastConnectAttempt = 0;
+  WiFiClientSecure    _tlsClient;
+  PubSubClient        _client;
+  PeripheralManager*  _manager    = nullptr;
+  TriggerEventQueue*  _eventQueue = nullptr;
+  String              _deviceId;
+  String              _mqttUsername;
+  String              _mqttPassword;
+  String              _mqttHost;
+  uint16_t            _mqttPort           = 8883;
+  unsigned long       _lastConnectAttempt = 0;
 };

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -14,6 +14,7 @@ using String = std::string;
 #include <time.h>
 #include "peripheral.h"
 #include "trigger.h"
+#include "../src/trigger_event_queue.h"
 
 struct PeripheralEntry {
   Peripheral* peripheral;
@@ -62,8 +63,12 @@ public:
   // Iterates all triggers, calling fn(trigger) for each.
   void forEachTrigger(std::function<void(Trigger*)> fn) const;
 
+  // Injects the event queue. Must be called before tickAll if triggers are used.
+  void setEventQueue(TriggerEventQueue& queue) { _eventQueue = &queue; }
+
 private:
   std::vector<PeripheralEntry> _entries;
   std::vector<Trigger*>        _triggers;
+  TriggerEventQueue*           _eventQueue = nullptr;
   bool _begun = false;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,3 +18,10 @@ lib_deps =
   bblanchon/ArduinoJson @ ^7.3.1
 build_src_filter = -<*>
 build_flags = -I test/stubs
+
+[env:test_trigger_event_queue]
+platform = native
+lib_deps =
+  bblanchon/ArduinoJson @ ^7.3.1
+build_src_filter = -<*>
+build_flags = -I test/stubs -I src

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "peripherals/ds18b20_sensor.h"
 #include "peripherals/relay_actuator.h"
 #include "trigger.h"
+#include "trigger_event_queue.h"
 #include "button.h"
 
 // ─── state machine ────────────────────────────────────────────────────────────
@@ -58,8 +59,9 @@ static void enterErrorRetry(State next, const char *reason)
 
 // ─── normal operation helpers ─────────────────────────────────────────────────
 
-static PeripheralManager manager;
-static FishHubMqttClient mqttClient;
+static PeripheralManager  manager;
+static FishHubMqttClient  mqttClient;
+static TriggerEventQueue  eventQueue;
 static bool normalOperationInitDone = false;
 
 static void restorePeripherals()
@@ -128,7 +130,8 @@ static void initNormalOperation()
   restorePeripherals();
   restoreTriggers();
   manager.beginAll();
-  mqttClient.begin(manager);
+  manager.setEventQueue(eventQueue);
+  mqttClient.begin(manager, eventQueue);
   normalOperationInitDone = true;
 }
 

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -4,6 +4,7 @@
 #include "peripherals/relay_actuator.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "trigger.h"
+#include "trigger_event_queue.h"
 #include <ArduinoJson.h>
 
 static const unsigned long RECONNECT_INTERVAL_MS = 5000;
@@ -43,8 +44,9 @@ emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----
 )EOF";
 
-void FishHubMqttClient::begin(PeripheralManager& manager) {
-  _manager = &manager;
+void FishHubMqttClient::begin(PeripheralManager& manager, TriggerEventQueue& eventQueue) {
+  _manager    = &manager;
+  _eventQueue = &eventQueue;
 
   _deviceId    = nvsStore.get("device_id");
   if (_deviceId.isEmpty()) _deviceId = DEVICE_ID;
@@ -78,6 +80,45 @@ void FishHubMqttClient::loop() {
     }
   }
   _client.loop();
+  drainEventQueue();
+}
+
+void FishHubMqttClient::drainEventQueue() {
+  if (!_eventQueue || !_client.connected()) return;
+
+  while (!_eventQueue->empty()) {
+    const TriggerEvent* ev = _eventQueue->front();
+
+    char topic[80];
+    snprintf(topic, sizeof(topic), "fishhub/%s/trigger_events", _deviceId.c_str());
+
+    JsonDocument doc;
+    doc["trigger_event_id"] = ev->triggerEventId;
+    doc["trigger_id"]       = ev->triggerId;
+    doc["device_id"]        = _deviceId.c_str();
+
+    char firedAtBuf[32];
+    struct tm* utc = gmtime(&ev->firedAt);
+    strftime(firedAtBuf, sizeof(firedAtBuf), "%Y-%m-%dT%H:%M:%SZ", utc);
+    doc["fired_at"] = firedAtBuf;
+
+    JsonArray readings = doc["readings"].to<JsonArray>();
+    for (size_t i = 0; i < ev->readingCount; i++) {
+      JsonObject r = readings.add<JsonObject>();
+      r["peripheral"] = ev->readings[i].peripheral;
+      r["value"]      = ev->readings[i].value;
+    }
+
+    char payload[512];
+    serializeJson(doc, payload, sizeof(payload));
+
+    if (_client.publish(topic, payload, /*retained=*/false)) {
+      _eventQueue->pop();
+    } else {
+      Serial.println("MQTT: trigger_event publish failed — will retry next loop");
+      break;
+    }
+  }
 }
 
 void FishHubMqttClient::connect() {

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -1,4 +1,6 @@
 #include "peripheral_manager.h"
+#include "trigger_event_queue.h"
+#include <cstring>
 
 #ifndef ARDUINO
 // millis() not available on native — callers always inject nowMs
@@ -53,7 +55,28 @@ String PeripheralManager::tickAll(time_t now, uint32_t nowMs) {
       e.peripheral->currentMeasurements(values);
     }
     for (auto* t : _triggers) {
-      t->evaluate(values, now, *this);
+      TriggerFired result = t->evaluate(values, now);
+      if (!result.fired) continue;
+
+      for (size_t ai = 0; ai < result.actions.size(); ai++)
+        dispatchCommand(String(result.actions[ai].first.c_str()),
+                        result.actions[ai].second.as<JsonObjectConst>());
+
+      if (_eventQueue) {
+        TriggerEvent ev = {};
+        strncpy(ev.triggerId, result.triggerId.c_str(), sizeof(ev.triggerId) - 1);
+        ev.firedAt = result.firedAt;
+        std::string id = makeTriggerEventId(ev.triggerId, ev.firedAt);
+        strncpy(ev.triggerEventId, id.c_str(), sizeof(ev.triggerEventId) - 1);
+        for (auto it = result.readings.begin(); it != result.readings.end(); ++it) {
+          if (ev.readingCount >= TRIGGER_EVENT_MAX_READINGS) break;
+          strncpy(ev.readings[ev.readingCount].peripheral,
+                  it->first.c_str(), sizeof(ev.readings[0].peripheral) - 1);
+          ev.readings[ev.readingCount].value = it->second;
+          ev.readingCount++;
+        }
+        _eventQueue->push(ev);
+      }
     }
   }
 

--- a/src/trigger.cpp
+++ b/src/trigger.cpp
@@ -1,5 +1,4 @@
 #include "trigger.h"
-#include "peripheral_manager.h"
 #include <cmath>
 #include <cstring>
 
@@ -7,208 +6,204 @@
 
 #ifdef ARDUINO
 #define TRIG_WARN(fmt, ...) Serial.printf("WARN [trigger]: " fmt "\n", ##__VA_ARGS__)
-#define TRIG_DBG(fmt, ...) Serial.printf("DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
+#define TRIG_DBG(fmt, ...)  Serial.printf("DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
 #else
 #include <cstdio>
 #define TRIG_WARN(fmt, ...) fprintf(stderr, "WARN [trigger]: " fmt "\n", ##__VA_ARGS__)
-#define TRIG_DBG(fmt, ...) fprintf(stderr, "DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
+#define TRIG_DBG(fmt, ...)  fprintf(stderr, "DBG  [trigger]: " fmt "\n", ##__VA_ARGS__)
 #endif
 
 bool Trigger::load(JsonObjectConst json)
 {
-  _id = json["id"] | "";
-  _enabled = json["enabled"] | false;
-  _cooldownS = json["cooldown_s"] | 60u;
-  _lastFiredAt = 0;
-  _actions.clear();
+    _id          = json["id"] | "";
+    _enabled     = json["enabled"] | false;
+    _cooldownS   = json["cooldown_s"] | 60u;
+    _lastFiredAt = 0;
+    _actions.clear();
 
-  _condDoc.set(json["condition"]);
+    _condDoc.set(json["condition"]);
 
-  for (JsonObjectConst a : json["actions"].as<JsonArrayConst>()) {
-    const char* type = a["type"] | "";
-    if (strcmp(type, "peripheral_action") != 0) continue;
+    for (JsonObjectConst a : json["actions"].as<JsonArrayConst>()) {
+        const char* type = a["type"] | "";
+        if (strcmp(type, "peripheral_action") != 0) continue;
 
-    JsonObjectConst cfg = a["config"].as<JsonObjectConst>();
-    PeripheralAction pa;
-    pa.peripheral = cfg["peripheral"] | "";
-    pa.actionDoc.set(cfg);
-    _actions.push_back(std::move(pa));
-  }
+        JsonObjectConst cfg = a["config"].as<JsonObjectConst>();
+        PeripheralAction pa;
+        pa.peripheral = cfg["peripheral"] | "";
+        pa.actionDoc.set(cfg);
+        _actions.push_back(std::move(pa));
+    }
 
-  return !_id.empty();
+    return !_id.empty();
 }
 
-bool Trigger::evaluate(const std::map<std::string, float> &values, time_t now,
-                       PeripheralManager &mgr)
+TriggerFired Trigger::evaluate(const std::map<std::string, float>& values, time_t now)
 {
-  if (!_enabled)
-    return false;
+    TriggerFired result;
 
-  bool periodic = (++_evalCount % TRIG_LOG_INTERVAL == 0);
+    if (!_enabled)
+        return result;
 
-  float result = evalNode(_condDoc.as<JsonObjectConst>(), values, periodic);
+    bool periodic = (++_evalCount % TRIG_LOG_INTERVAL == 0);
 
-  if (result == 0.0f || std::isnan(result))
-  {
-    if (periodic)
-      TRIG_DBG("'%s' condition false (tick %lu)", _id.c_str(), (unsigned long)_evalCount);
-    return false;
-  }
+    float cond = evalNode(_condDoc.as<JsonObjectConst>(), values, periodic);
 
-  if (_lastFiredAt != 0 && (now - _lastFiredAt) < (time_t)_cooldownS)
-  {
-    if (periodic)
-      TRIG_DBG("'%s' condition true but in cooldown (%lus remaining)",
-               _id.c_str(), (unsigned long)(_cooldownS - (now - _lastFiredAt)));
-    return false;
-  }
+    if (cond == 0.0f || std::isnan(cond)) {
+        if (periodic)
+            TRIG_DBG("'%s' condition false (tick %lu)", _id.c_str(), (unsigned long)_evalCount);
+        return result;
+    }
 
-  TRIG_DBG("'%s' FIRING %zu action(s) (tick %lu)", _id.c_str(), _actions.size(),
-           (unsigned long)_evalCount);
-  applyTo(mgr);
-  _lastFiredAt = now;
-  return true;
+    if (_lastFiredAt != 0 && (now - _lastFiredAt) < (time_t)_cooldownS) {
+        if (periodic)
+            TRIG_DBG("'%s' condition true but in cooldown (%lus remaining)",
+                     _id.c_str(), (unsigned long)(_cooldownS - (now - _lastFiredAt)));
+        return result;
+    }
+
+    TRIG_DBG("'%s' FIRING %zu action(s) (tick %lu)", _id.c_str(), _actions.size(),
+             (unsigned long)_evalCount);
+
+    result.fired     = true;
+    result.firedAt   = now;
+    result.triggerId = _id;
+
+    for (const auto& a : _actions) {
+        result.actions.emplace_back(a.peripheral, JsonDocument{});
+        result.actions.back().second.set(a.actionDoc.as<JsonObjectConst>());
+    }
+
+    collectMeasurements(_condDoc.as<JsonObjectConst>(), values, result);
+
+    _lastFiredAt = now;
+    return result;
+}
+
+void Trigger::collectMeasurements(JsonObjectConst node,
+                                  const std::map<std::string, float>& values,
+                                  TriggerFired& out) const
+{
+    const char* op = node["op"] | "";
+
+    if (strcmp(op, "value") == 0) {
+        const char* name = node["measurement"] | "";
+        auto it = values.find(name);
+        if (it != values.end())
+            out.readings[name] = it->second;
+        return;
+    }
+
+    // Recurse into children
+    if (!node["left"].isNull())
+        collectMeasurements(node["left"].as<JsonObjectConst>(), values, out);
+    if (!node["right"].isNull())
+        collectMeasurements(node["right"].as<JsonObjectConst>(), values, out);
 }
 
 float Trigger::evalNode(JsonObjectConst node,
-                        const std::map<std::string, float> &values, bool log) const
+                        const std::map<std::string, float>& values, bool log) const
 {
-  const char *op = node["op"] | "";
+    const char* op = node["op"] | "";
 
-  if (strcmp(op, "value") == 0)
-  {
-    const char *name = node["measurement"] | "";
-    auto it = values.find(name);
-    float v = (it != values.end()) ? it->second : NAN;
-    if (log)
-      TRIG_DBG("    value('%s') = %.4f", name, v);
-    return v;
-  }
-
-  if (strcmp(op, "literal") == 0)
-  {
-    float v = node["value"] | 0.0f;
-    if (log)
-      TRIG_DBG("    literal = %.4f", v);
-    return v;
-  }
-
-  if (strcmp(op, "not") == 0)
-  {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
-    float v = (l == 0.0f || std::isnan(l)) ? 1.0f : 0.0f;
-    if (log)
-      TRIG_DBG("    not(%.4f) = %.4f", l, v);
-    return v;
-  }
-
-  if (strcmp(op, "and") == 0)
-  {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
-    if (l == 0.0f || std::isnan(l))
-    {
-      if (log)
-        TRIG_DBG("    and: left=%.4f => short-circuit false", l);
-      return 0.0f;
+    if (strcmp(op, "value") == 0) {
+        const char* name = node["measurement"] | "";
+        auto it = values.find(name);
+        float v = (it != values.end()) ? it->second : NAN;
+        if (log)
+            TRIG_DBG("    value('%s') = %.4f", name, v);
+        return v;
     }
+
+    if (strcmp(op, "literal") == 0) {
+        float v = node["value"] | 0.0f;
+        if (log)
+            TRIG_DBG("    literal = %.4f", v);
+        return v;
+    }
+
+    if (strcmp(op, "not") == 0) {
+        float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+        float v = (l == 0.0f || std::isnan(l)) ? 1.0f : 0.0f;
+        if (log)
+            TRIG_DBG("    not(%.4f) = %.4f", l, v);
+        return v;
+    }
+
+    if (strcmp(op, "and") == 0) {
+        float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+        if (l == 0.0f || std::isnan(l)) {
+            if (log)
+                TRIG_DBG("    and: left=%.4f => short-circuit false", l);
+            return 0.0f;
+        }
+        float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
+        float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+        if (log)
+            TRIG_DBG("    and(%.4f, %.4f) = %.4f", l, r, v);
+        return v;
+    }
+
+    if (strcmp(op, "or") == 0) {
+        float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
+        if (l != 0.0f && !std::isnan(l)) {
+            if (log)
+                TRIG_DBG("    or: left=%.4f => short-circuit true", l);
+            return 1.0f;
+        }
+        float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
+        float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+        if (log)
+            TRIG_DBG("    or(%.4f, %.4f) = %.4f", l, r, v);
+        return v;
+    }
+
+    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
     float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
-    float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
-    if (log)
-      TRIG_DBG("    and(%.4f, %.4f) = %.4f", l, r, v);
-    return v;
-  }
+    float v = 0.0f;
 
-  if (strcmp(op, "or") == 0)
-  {
-    float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
-    if (l != 0.0f && !std::isnan(l))
-    {
-      if (log)
-        TRIG_DBG("    or: left=%.4f => short-circuit true", l);
-      return 1.0f;
+    if (strcmp(op, "add") == 0) {
+        v = l + r;
+    } else if (strcmp(op, "sub") == 0) {
+        v = l - r;
+    } else if (strcmp(op, "mul") == 0) {
+        v = l * r;
+    } else if (strcmp(op, "div") == 0) {
+        if (r == 0.0f) {
+            TRIG_WARN("division by zero in trigger '%s'", _id.c_str());
+            return 0.0f;
+        }
+        v = l / r;
+    } else if (strcmp(op, "lt") == 0) {
+        v = (l < r) ? 1.0f : 0.0f;
+    } else if (strcmp(op, "lte") == 0) {
+        v = (l <= r) ? 1.0f : 0.0f;
+    } else if (strcmp(op, "gt") == 0) {
+        v = (l > r) ? 1.0f : 0.0f;
+    } else if (strcmp(op, "gte") == 0) {
+        v = (l >= r) ? 1.0f : 0.0f;
+    } else if (strcmp(op, "eq") == 0) {
+        v = (l == r) ? 1.0f : 0.0f;
+    } else {
+        TRIG_WARN("unknown op '%s' in trigger '%s'", op, _id.c_str());
     }
-    float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
-    float v = (r != 0.0f && !std::isnan(r)) ? 1.0f : 0.0f;
+
     if (log)
-      TRIG_DBG("    or(%.4f, %.4f) = %.4f", l, r, v);
+        TRIG_DBG("    %s(%.4f, %.4f) = %.4f", op, l, r, v);
     return v;
-  }
-
-  float l = evalNode(node["left"].as<JsonObjectConst>(), values, log);
-  float r = evalNode(node["right"].as<JsonObjectConst>(), values, log);
-  float v = 0.0f;
-
-  if (strcmp(op, "add") == 0)
-  {
-    v = l + r;
-  }
-  else if (strcmp(op, "sub") == 0)
-  {
-    v = l - r;
-  }
-  else if (strcmp(op, "mul") == 0)
-  {
-    v = l * r;
-  }
-  else if (strcmp(op, "div") == 0)
-  {
-    if (r == 0.0f)
-    {
-      TRIG_WARN("division by zero in trigger '%s'", _id.c_str());
-      return 0.0f;
-    }
-    v = l / r;
-  }
-  else if (strcmp(op, "lt") == 0)
-  {
-    v = (l < r) ? 1.0f : 0.0f;
-  }
-  else if (strcmp(op, "lte") == 0)
-  {
-    v = (l <= r) ? 1.0f : 0.0f;
-  }
-  else if (strcmp(op, "gt") == 0)
-  {
-    v = (l > r) ? 1.0f : 0.0f;
-  }
-  else if (strcmp(op, "gte") == 0)
-  {
-    v = (l >= r) ? 1.0f : 0.0f;
-  }
-  else if (strcmp(op, "eq") == 0)
-  {
-    v = (l == r) ? 1.0f : 0.0f;
-  }
-  else
-  {
-    TRIG_WARN("unknown op '%s' in trigger '%s'", op, _id.c_str());
-  }
-
-  if (log)
-    TRIG_DBG("    %s(%.4f, %.4f) = %.4f", op, l, r, v);
-  return v;
 }
 
 void Trigger::serializeTo(JsonObject out) const
 {
-  out["op"]         = "upsert";
-  out["id"]         = _id.c_str();
-  out["enabled"]    = _enabled;
-  out["cooldown_s"] = _cooldownS;
-  out["condition"]  = _condDoc.as<JsonObjectConst>();
+    out["op"]         = "upsert";
+    out["id"]         = _id.c_str();
+    out["enabled"]    = _enabled;
+    out["cooldown_s"] = _cooldownS;
+    out["condition"]  = _condDoc.as<JsonObjectConst>();
 
-  JsonArray arr = out["actions"].to<JsonArray>();
-  for (const auto& a : _actions) {
-    JsonObject entry = arr.add<JsonObject>();
-    entry["type"]   = "peripheral_action";
-    entry["config"] = a.actionDoc.as<JsonObjectConst>();
-  }
-}
-
-void Trigger::applyTo(PeripheralManager &mgr) const
-{
-  for (const auto& a : _actions) {
-    mgr.dispatchCommand(String(a.peripheral.c_str()),
-                        a.actionDoc.as<JsonObjectConst>());
-  }
+    JsonArray arr = out["actions"].to<JsonArray>();
+    for (const auto& a : _actions) {
+        JsonObject entry = arr.add<JsonObject>();
+        entry["type"]   = "peripheral_action";
+        entry["config"] = a.actionDoc.as<JsonObjectConst>();
+    }
 }

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -13,33 +13,41 @@ using String = std::string;
 #include <vector>
 #include <time.h>
 
-// Forward declaration to avoid circular include with peripheral_manager.h
-class PeripheralManager;
+struct TriggerFired {
+    bool fired = false;
+    // (peripheral name, action doc) pairs to dispatch
+    std::vector<std::pair<std::string, JsonDocument>> actions;
+    // measurement values referenced in the condition tree
+    std::map<std::string, float> readings;
+    time_t      firedAt   = 0;
+    std::string triggerId;
+};
 
 class Trigger {
 public:
-  bool load(JsonObjectConst json);
-  bool evaluate(const std::map<std::string, float>& values, time_t now,
-                PeripheralManager& mgr);
-  void serializeTo(JsonObject out) const;
-  const std::string& id() const { return _id; }
-  bool enabled() const { return _enabled; }
+    bool        load(JsonObjectConst json);
+    TriggerFired evaluate(const std::map<std::string, float>& values, time_t now);
+    void        serializeTo(JsonObject out) const;
+    const std::string& id() const { return _id; }
+    bool        enabled() const { return _enabled; }
 
 private:
-  float evalNode(JsonObjectConst node,
-                 const std::map<std::string, float>& values, bool log) const;
-  void  applyTo(PeripheralManager& mgr) const;
+    float evalNode(JsonObjectConst node,
+                   const std::map<std::string, float>& values, bool log) const;
+    void  collectMeasurements(JsonObjectConst node,
+                              const std::map<std::string, float>& values,
+                              TriggerFired& out) const;
 
-  struct PeripheralAction {
-    std::string  peripheral;
-    JsonDocument actionDoc;
-  };
+    struct PeripheralAction {
+        std::string  peripheral;
+        JsonDocument actionDoc;
+    };
 
-  std::string                  _id;
-  bool                         _enabled     = false;
-  JsonDocument                 _condDoc;
-  std::vector<PeripheralAction> _actions;
-  uint32_t                     _cooldownS   = 60;
-  time_t          _lastFiredAt = 0;
-  uint32_t        _evalCount   = 0;
+    std::string                   _id;
+    bool                          _enabled   = false;
+    JsonDocument                  _condDoc;
+    std::vector<PeripheralAction> _actions;
+    uint32_t                      _cooldownS  = 60;
+    time_t                        _lastFiredAt = 0;
+    uint32_t                      _evalCount  = 0;
 };

--- a/src/trigger_event_queue.cpp
+++ b/src/trigger_event_queue.cpp
@@ -1,0 +1,50 @@
+#include "trigger_event_queue.h"
+#include <cstdio>
+#include <cstring>
+
+// Base64 alphabet
+static const char B64[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static std::string base64Encode(const char* src, size_t len) {
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    for (size_t i = 0; i < len; i += 3) {
+        unsigned char b0 = (unsigned char)src[i];
+        unsigned char b1 = (i + 1 < len) ? (unsigned char)src[i + 1] : 0;
+        unsigned char b2 = (i + 2 < len) ? (unsigned char)src[i + 2] : 0;
+        out += B64[b0 >> 2];
+        out += B64[((b0 & 0x03) << 4) | (b1 >> 4)];
+        out += (i + 1 < len) ? B64[((b1 & 0x0f) << 2) | (b2 >> 6)] : '=';
+        out += (i + 2 < len) ? B64[b2 & 0x3f] : '=';
+    }
+    return out;
+}
+
+std::string makeTriggerEventId(const char* triggerId, time_t firedAt) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%s:%ld", triggerId, (long)firedAt);
+    return base64Encode(buf, strlen(buf));
+}
+
+void TriggerEventQueue::push(const TriggerEvent& e) {
+    if (_count == TRIGGER_EVENT_QUEUE_CAPACITY) {
+        // Drop oldest: advance head
+        _head  = (_head + 1) % TRIGGER_EVENT_QUEUE_CAPACITY;
+        _count--;
+    }
+    size_t tail = (_head + _count) % TRIGGER_EVENT_QUEUE_CAPACITY;
+    _buf[tail] = e;
+    _count++;
+}
+
+const TriggerEvent* TriggerEventQueue::front() const {
+    if (_count == 0) return nullptr;
+    return &_buf[_head];
+}
+
+void TriggerEventQueue::pop() {
+    if (_count == 0) return;
+    _head  = (_head + 1) % TRIGGER_EVENT_QUEUE_CAPACITY;
+    _count--;
+}

--- a/src/trigger_event_queue.h
+++ b/src/trigger_event_queue.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <time.h>
+#include <cstddef>
+
+static constexpr size_t TRIGGER_EVENT_QUEUE_CAPACITY = 32;
+static constexpr size_t TRIGGER_EVENT_MAX_READINGS   = 8;
+
+struct TriggerEventReading {
+    char  peripheral[48];
+    float value;
+    char  unit[16];
+};
+
+struct TriggerEvent {
+    char               triggerEventId[65]; // base64(<triggerId>:<firedAt>) + null
+    char               triggerId[37];      // UUID (36 + null)
+    time_t             firedAt;
+    TriggerEventReading readings[TRIGGER_EVENT_MAX_READINGS];
+    size_t             readingCount = 0;
+};
+
+// Deterministic opaque ID derived from triggerId and firedAt via base64.
+// Server deduplicates on (trigger_id, fired_at); this is just a stable handle.
+std::string makeTriggerEventId(const char* triggerId, time_t firedAt);
+
+class TriggerEventQueue {
+public:
+    // Enqueues an event. Drops the oldest entry if at capacity.
+    void push(const TriggerEvent& e);
+
+    const TriggerEvent* front() const;
+    void pop();
+    bool empty() const { return _count == 0; }
+    size_t size() const { return _count; }
+
+private:
+    TriggerEvent _buf[TRIGGER_EVENT_QUEUE_CAPACITY];
+    size_t       _head  = 0;
+    size_t       _count = 0;
+};

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -8,6 +8,7 @@
 #include "../../src/peripheral_manager.cpp"
 #include "../../src/schedule.cpp"
 #include "../../src/trigger.cpp"
+#include "../../src/trigger_event_queue.cpp"
 
 // ── mock peripheral ──────────────────────────────────────────────────────────
 

--- a/test/test_trigger/test_trigger.cpp
+++ b/test/test_trigger/test_trigger.cpp
@@ -5,14 +5,11 @@
 #include <string>
 #include <map>
 
-#include "peripheral_manager.h"
-#include "../../src/peripheral_manager.cpp"
 #include "../../src/trigger.cpp"
+#include "../../src/trigger_event_queue.cpp"
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-// Build and evaluate a trigger whose condition is condJson.
-// A fresh Trigger and PeripheralManager are created for each call.
 static bool evalCond(const char* condJson,
                      const std::map<std::string, float>& values,
                      time_t now = 1000) {
@@ -24,33 +21,11 @@ static bool evalCond(const char* condJson,
   deserializeJson(doc, json.c_str());
   Trigger t;
   t.load(doc.as<JsonObjectConst>());
-  PeripheralManager mgr;
-  return t.evaluate(values, now, mgr);
+  return t.evaluate(values, now).fired;
 }
 
 static const char* COMPOUND =
   R"({"op":"or","left":{"op":"gt","left":{"op":"add","left":{"op":"value","measurement":"ds18b20-4/temperature"},"right":{"op":"value","measurement":"ds18b20-5/temperature"}},"right":{"op":"literal","value":38}},"right":{"op":"lt","left":{"op":"value","measurement":"ds18b20-4/temperature"},"right":{"op":"literal","value":18}}})";
-
-// ── stub peripheral ───────────────────────────────────────────────────────────
-
-struct RecordingPeripheral : public Peripheral {
-  const char* _name;
-  int         callCount = 0;
-  JsonDocument lastCmd;
-
-  explicit RecordingPeripheral(const char* name) : _name(name) {}
-
-  const char* name() const override { return _name; }
-  void begin() override {}
-  uint32_t intervalMs() const override { return 1000; }
-  bool tick(time_t) override { return false; }
-  void appendSenML(JsonArray&, time_t) override {}
-
-  void applyCommand(JsonObjectConst cmd) override {
-    callCount++;
-    lastCmd.set(cmd);
-  }
-};
 
 // ── leaf nodes ────────────────────────────────────────────────────────────────
 
@@ -61,7 +36,6 @@ void test_value_hit(void) {
 }
 
 void test_value_miss_nan_propagation(void) {
-  // Missing key → NAN; NAN > 0 is false in IEEE 754
   bool r = evalCond(R"({"op":"gt","left":{"op":"value","measurement":"missing"},"right":{"op":"literal","value":0}})",
                     {});
   TEST_ASSERT_FALSE(r);
@@ -76,7 +50,6 @@ void test_literal(void) {
 // ── arithmetic ────────────────────────────────────────────────────────────────
 
 void test_add(void) {
-  // 3 + 4 = 7 > 6
   bool r = evalCond(
     R"({"op":"gt","left":{"op":"add","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}},"right":{"op":"literal","value":6}})",
     {});
@@ -84,7 +57,6 @@ void test_add(void) {
 }
 
 void test_sub(void) {
-  // 10 - 3 = 7 > 6
   bool r = evalCond(
     R"({"op":"gt","left":{"op":"sub","left":{"op":"literal","value":10},"right":{"op":"literal","value":3}},"right":{"op":"literal","value":6}})",
     {});
@@ -92,7 +64,6 @@ void test_sub(void) {
 }
 
 void test_mul(void) {
-  // 3 * 4 = 12 > 11
   bool r = evalCond(
     R"({"op":"gt","left":{"op":"mul","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}},"right":{"op":"literal","value":11}})",
     {});
@@ -100,7 +71,6 @@ void test_mul(void) {
 }
 
 void test_div(void) {
-  // 10 / 4 = 2.5 > 2
   bool r = evalCond(
     R"({"op":"gt","left":{"op":"div","left":{"op":"literal","value":10},"right":{"op":"literal","value":4}},"right":{"op":"literal","value":2}})",
     {});
@@ -108,7 +78,6 @@ void test_div(void) {
 }
 
 void test_div_by_zero(void) {
-  // 10 / 0 → 0.0; 0 > 5 → false
   bool r = evalCond(
     R"({"op":"gt","left":{"op":"div","left":{"op":"literal","value":10},"right":{"op":"literal","value":0}},"right":{"op":"literal","value":5}})",
     {});
@@ -117,100 +86,55 @@ void test_div_by_zero(void) {
 
 // ── comparisons ───────────────────────────────────────────────────────────────
 
-void test_lt_true(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"lt","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}})", {}));
-}
-void test_lt_false(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"lt","left":{"op":"literal","value":4},"right":{"op":"literal","value":3}})", {}));
-}
+void test_lt_true(void)  { TEST_ASSERT_TRUE(evalCond(R"({"op":"lt","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}})", {})); }
+void test_lt_false(void) { TEST_ASSERT_FALSE(evalCond(R"({"op":"lt","left":{"op":"literal","value":4},"right":{"op":"literal","value":3}})", {})); }
 
-void test_lte_true(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"lte","left":{"op":"literal","value":4},"right":{"op":"literal","value":4}})", {}));
-}
-void test_lte_false(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"lte","left":{"op":"literal","value":5},"right":{"op":"literal","value":4}})", {}));
-}
+void test_lte_true(void)  { TEST_ASSERT_TRUE(evalCond(R"({"op":"lte","left":{"op":"literal","value":4},"right":{"op":"literal","value":4}})", {})); }
+void test_lte_false(void) { TEST_ASSERT_FALSE(evalCond(R"({"op":"lte","left":{"op":"literal","value":5},"right":{"op":"literal","value":4}})", {})); }
 
-void test_gt_true(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"gt","left":{"op":"literal","value":5},"right":{"op":"literal","value":4}})", {}));
-}
-void test_gt_false(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"gt","left":{"op":"literal","value":4},"right":{"op":"literal","value":5}})", {}));
-}
+void test_gt_true(void)  { TEST_ASSERT_TRUE(evalCond(R"({"op":"gt","left":{"op":"literal","value":5},"right":{"op":"literal","value":4}})", {})); }
+void test_gt_false(void) { TEST_ASSERT_FALSE(evalCond(R"({"op":"gt","left":{"op":"literal","value":4},"right":{"op":"literal","value":5}})", {})); }
 
-void test_gte_true(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"gte","left":{"op":"literal","value":4},"right":{"op":"literal","value":4}})", {}));
-}
-void test_gte_false(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"gte","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}})", {}));
-}
+void test_gte_true(void)  { TEST_ASSERT_TRUE(evalCond(R"({"op":"gte","left":{"op":"literal","value":4},"right":{"op":"literal","value":4}})", {})); }
+void test_gte_false(void) { TEST_ASSERT_FALSE(evalCond(R"({"op":"gte","left":{"op":"literal","value":3},"right":{"op":"literal","value":4}})", {})); }
 
-void test_eq_true(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"eq","left":{"op":"literal","value":7},"right":{"op":"literal","value":7}})", {}));
-}
-void test_eq_false(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"eq","left":{"op":"literal","value":7},"right":{"op":"literal","value":8}})", {}));
-}
+void test_eq_true(void)  { TEST_ASSERT_TRUE(evalCond(R"({"op":"eq","left":{"op":"literal","value":7},"right":{"op":"literal","value":7}})", {})); }
+void test_eq_false(void) { TEST_ASSERT_FALSE(evalCond(R"({"op":"eq","left":{"op":"literal","value":7},"right":{"op":"literal","value":8}})", {})); }
 
 // ── logical ───────────────────────────────────────────────────────────────────
 
 void test_and_both_true(void) {
-  TEST_ASSERT_TRUE(evalCond(
-    R"({"op":"and","left":{"op":"literal","value":1},"right":{"op":"literal","value":1}})", {}));
+  TEST_ASSERT_TRUE(evalCond(R"({"op":"and","left":{"op":"literal","value":1},"right":{"op":"literal","value":1}})", {}));
 }
-
 void test_and_short_circuit_left_false(void) {
-  // left is false → short-circuits to false without evaluating right
-  TEST_ASSERT_FALSE(evalCond(
-    R"({"op":"and","left":{"op":"literal","value":0},"right":{"op":"literal","value":1}})", {}));
+  TEST_ASSERT_FALSE(evalCond(R"({"op":"and","left":{"op":"literal","value":0},"right":{"op":"literal","value":1}})", {}));
 }
-
 void test_and_right_false(void) {
-  TEST_ASSERT_FALSE(evalCond(
-    R"({"op":"and","left":{"op":"literal","value":1},"right":{"op":"literal","value":0}})", {}));
+  TEST_ASSERT_FALSE(evalCond(R"({"op":"and","left":{"op":"literal","value":1},"right":{"op":"literal","value":0}})", {}));
 }
-
 void test_or_short_circuit_left_true(void) {
-  // left is true → short-circuits to true without evaluating right
-  TEST_ASSERT_TRUE(evalCond(
-    R"({"op":"or","left":{"op":"literal","value":1},"right":{"op":"literal","value":0}})", {}));
+  TEST_ASSERT_TRUE(evalCond(R"({"op":"or","left":{"op":"literal","value":1},"right":{"op":"literal","value":0}})", {}));
 }
-
 void test_or_right_true(void) {
-  TEST_ASSERT_TRUE(evalCond(
-    R"({"op":"or","left":{"op":"literal","value":0},"right":{"op":"literal","value":1}})", {}));
+  TEST_ASSERT_TRUE(evalCond(R"({"op":"or","left":{"op":"literal","value":0},"right":{"op":"literal","value":1}})", {}));
 }
-
 void test_or_both_false(void) {
-  TEST_ASSERT_FALSE(evalCond(
-    R"({"op":"or","left":{"op":"literal","value":0},"right":{"op":"literal","value":0}})", {}));
+  TEST_ASSERT_FALSE(evalCond(R"({"op":"or","left":{"op":"literal","value":0},"right":{"op":"literal","value":0}})", {}));
 }
-
-void test_not_of_true(void) {
-  TEST_ASSERT_FALSE(evalCond(R"({"op":"not","left":{"op":"literal","value":1}})", {}));
-}
-
-void test_not_of_false(void) {
-  TEST_ASSERT_TRUE(evalCond(R"({"op":"not","left":{"op":"literal","value":0}})", {}));
-}
+void test_not_of_true(void)  { TEST_ASSERT_FALSE(evalCond(R"({"op":"not","left":{"op":"literal","value":1}})", {})); }
+void test_not_of_false(void) { TEST_ASSERT_TRUE(evalCond(R"({"op":"not","left":{"op":"literal","value":0}})", {})); }
 
 // ── compound ──────────────────────────────────────────────────────────────────
-// (ds18b20-4/temperature + ds18b20-5/temperature > 38) or (ds18b20-4/temperature < 18)
 
 void test_compound_first_branch_true(void) {
-  // 20 + 20 = 40 > 38 → true
   TEST_ASSERT_TRUE(evalCond(COMPOUND,
     {{"ds18b20-4/temperature", 20.0f}, {"ds18b20-5/temperature", 20.0f}}));
 }
-
 void test_compound_second_branch_true(void) {
-  // 10 + 10 = 20, not > 38; but 10 < 18 → true
   TEST_ASSERT_TRUE(evalCond(COMPOUND,
     {{"ds18b20-4/temperature", 10.0f}, {"ds18b20-5/temperature", 10.0f}}));
 }
-
 void test_compound_both_false(void) {
-  // 20 + 15 = 35, not > 38; and 20 not < 18 → false
   TEST_ASSERT_FALSE(evalCond(COMPOUND,
     {{"ds18b20-4/temperature", 20.0f}, {"ds18b20-5/temperature", 15.0f}}));
 }
@@ -223,11 +147,10 @@ void test_cooldown_prevents_refire(void) {
     R"({"id":"t","enabled":true,"actions":[],"cooldown_s":60,"condition":{"op":"literal","value":1}})");
   Trigger t;
   t.load(doc.as<JsonObjectConst>());
-  PeripheralManager mgr;
 
-  TEST_ASSERT_TRUE(t.evaluate({}, 1000, mgr));   // first fire
-  TEST_ASSERT_FALSE(t.evaluate({}, 1050, mgr));  // within cooldown
-  TEST_ASSERT_TRUE(t.evaluate({}, 1061, mgr));   // beyond cooldown
+  TEST_ASSERT_TRUE(t.evaluate({}, 1000).fired);   // first fire
+  TEST_ASSERT_FALSE(t.evaluate({}, 1050).fired);  // within cooldown
+  TEST_ASSERT_TRUE(t.evaluate({}, 1061).fired);   // beyond cooldown
 }
 
 // ── disabled ──────────────────────────────────────────────────────────────────
@@ -238,9 +161,8 @@ void test_disabled_does_not_fire(void) {
     R"({"id":"t","enabled":false,"actions":[],"condition":{"op":"literal","value":1}})");
   Trigger t;
   t.load(doc.as<JsonObjectConst>());
-  PeripheralManager mgr;
 
-  TEST_ASSERT_FALSE(t.evaluate({}, 1000, mgr));
+  TEST_ASSERT_FALSE(t.evaluate({}, 1000).fired);
 }
 
 // ── actions array ─────────────────────────────────────────────────────────────
@@ -260,15 +182,12 @@ void test_load_single_action(void) {
   Trigger t;
   t.load(doc.as<JsonObjectConst>());
 
-  auto* p = new RecordingPeripheral("relay-16");
-  PeripheralManager mgr;
-  mgr.add(p);
-
-  bool fired = t.evaluate({}, 1000, mgr);
-  TEST_ASSERT_TRUE(fired);
-  TEST_ASSERT_EQUAL(1, p->callCount);
-  TEST_ASSERT_EQUAL_STRING("set", p->lastCmd["command"] | "");
-  TEST_ASSERT_EQUAL_INT(1, p->lastCmd["value"] | 0);
+  TriggerFired result = t.evaluate({}, 1000);
+  TEST_ASSERT_TRUE(result.fired);
+  TEST_ASSERT_EQUAL(1, result.actions.size());
+  TEST_ASSERT_EQUAL_STRING("relay-16", result.actions[0].first.c_str());
+  TEST_ASSERT_EQUAL_STRING("set", result.actions[0].second["command"] | "");
+  TEST_ASSERT_EQUAL_INT(1, result.actions[0].second["value"] | 0);
 }
 
 void test_load_unknown_type_skipped(void) {
@@ -286,17 +205,12 @@ void test_load_unknown_type_skipped(void) {
   Trigger t;
   t.load(doc.as<JsonObjectConst>());
 
-  auto* p = new RecordingPeripheral("relay-16");
-  PeripheralManager mgr;
-  mgr.add(p);
-
-  t.evaluate({}, 1000, mgr);
-  // Unknown type must be silently skipped — peripheral never called
-  TEST_ASSERT_EQUAL(0, p->callCount);
+  TriggerFired result = t.evaluate({}, 1000);
+  TEST_ASSERT_TRUE(result.fired);
+  TEST_ASSERT_EQUAL(0, result.actions.size());
 }
 
 void test_load_many_actions(void) {
-  // 5 peripheral_action entries — all must be dispatched
   JsonDocument doc;
   deserializeJson(doc, R"({
     "id": "t3",
@@ -316,22 +230,9 @@ void test_load_many_actions(void) {
   bool ok = t.load(doc.as<JsonObjectConst>());
   TEST_ASSERT_TRUE(ok);
 
-  auto* r1 = new RecordingPeripheral("r1");
-  auto* r2 = new RecordingPeripheral("r2");
-  auto* r3 = new RecordingPeripheral("r3");
-  auto* r4 = new RecordingPeripheral("r4");
-  auto* r5 = new RecordingPeripheral("r5");
-  PeripheralManager mgr;
-  mgr.add(r1); mgr.add(r2); mgr.add(r3); mgr.add(r4); mgr.add(r5);
-
-  t.evaluate({}, 1000, mgr);
-
-  // All 5 actions must be dispatched
-  TEST_ASSERT_EQUAL(1, r1->callCount);
-  TEST_ASSERT_EQUAL(1, r2->callCount);
-  TEST_ASSERT_EQUAL(1, r3->callCount);
-  TEST_ASSERT_EQUAL(1, r4->callCount);
-  TEST_ASSERT_EQUAL(1, r5->callCount);
+  TriggerFired result = t.evaluate({}, 1000);
+  TEST_ASSERT_TRUE(result.fired);
+  TEST_ASSERT_EQUAL(5, result.actions.size());
 }
 
 void test_serialize_round_trip(void) {
@@ -350,7 +251,6 @@ void test_serialize_round_trip(void) {
   Trigger t;
   t.load(loadDoc.as<JsonObjectConst>());
 
-  // Serialize into a new document
   JsonDocument outDoc;
   t.serializeTo(outDoc.to<JsonObject>());
 

--- a/test/test_trigger_event_queue/test_main.cpp
+++ b/test/test_trigger_event_queue/test_main.cpp
@@ -1,0 +1,212 @@
+#include <unity.h>
+#include <ArduinoJson.h>
+#include <cstring>
+#include <map>
+#include <string>
+
+#include "../../src/trigger_event_queue.cpp"
+#include "../../src/trigger.cpp"
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+static TriggerEvent makeEvent(const char* triggerId, time_t firedAt) {
+  TriggerEvent ev = {};
+  strncpy(ev.triggerId, triggerId, sizeof(ev.triggerId) - 1);
+  ev.firedAt = firedAt;
+  std::string id = makeTriggerEventId(triggerId, firedAt);
+  strncpy(ev.triggerEventId, id.c_str(), sizeof(ev.triggerEventId) - 1);
+  return ev;
+}
+
+// ── queue tests ───────────────────────────────────────────────────────────────
+
+void test_queue_empty_on_init(void) {
+  TriggerEventQueue q;
+  TEST_ASSERT_TRUE(q.empty());
+  TEST_ASSERT_EQUAL(0, q.size());
+  TEST_ASSERT_NULL(q.front());
+}
+
+void test_queue_push_pop(void) {
+  TriggerEventQueue q;
+  TriggerEvent ev = makeEvent("abc-123", 1000);
+  q.push(ev);
+
+  TEST_ASSERT_FALSE(q.empty());
+  TEST_ASSERT_EQUAL(1, q.size());
+
+  const TriggerEvent* front = q.front();
+  TEST_ASSERT_NOT_NULL(front);
+  TEST_ASSERT_EQUAL_STRING("abc-123", front->triggerId);
+  TEST_ASSERT_EQUAL(1000, front->firedAt);
+
+  q.pop();
+  TEST_ASSERT_TRUE(q.empty());
+  TEST_ASSERT_NULL(q.front());
+}
+
+void test_queue_fifo_order(void) {
+  TriggerEventQueue q;
+  q.push(makeEvent("t1", 1000));
+  q.push(makeEvent("t2", 2000));
+  q.push(makeEvent("t3", 3000));
+
+  TEST_ASSERT_EQUAL_STRING("t1", q.front()->triggerId);
+  q.pop();
+  TEST_ASSERT_EQUAL_STRING("t2", q.front()->triggerId);
+  q.pop();
+  TEST_ASSERT_EQUAL_STRING("t3", q.front()->triggerId);
+  q.pop();
+  TEST_ASSERT_TRUE(q.empty());
+}
+
+void test_queue_overflow_drops_oldest(void) {
+  TriggerEventQueue q;
+
+  // Fill to capacity
+  for (size_t i = 0; i < TRIGGER_EVENT_QUEUE_CAPACITY; i++) {
+    char id[8];
+    snprintf(id, sizeof(id), "t%02zu", i);
+    q.push(makeEvent(id, (time_t)i));
+  }
+  TEST_ASSERT_EQUAL(TRIGGER_EVENT_QUEUE_CAPACITY, q.size());
+  TEST_ASSERT_EQUAL_STRING("t00", q.front()->triggerId);
+
+  // One more — oldest (t00) should be dropped
+  q.push(makeEvent("tXX", 999));
+  TEST_ASSERT_EQUAL(TRIGGER_EVENT_QUEUE_CAPACITY, q.size());
+  TEST_ASSERT_EQUAL_STRING("t01", q.front()->triggerId);
+
+  // Last element must be the overflow one
+  for (size_t i = 0; i < TRIGGER_EVENT_QUEUE_CAPACITY - 1; i++) q.pop();
+  TEST_ASSERT_EQUAL_STRING("tXX", q.front()->triggerId);
+}
+
+// ── makeTriggerEventId tests ──────────────────────────────────────────────────
+
+void test_make_trigger_event_id_deterministic(void) {
+  std::string a = makeTriggerEventId("trigger-uuid-1234", 1700000000);
+  std::string b = makeTriggerEventId("trigger-uuid-1234", 1700000000);
+  TEST_ASSERT_EQUAL_STRING(a.c_str(), b.c_str());
+}
+
+void test_make_trigger_event_id_different_firedAt(void) {
+  std::string a = makeTriggerEventId("trigger-uuid-1234", 1700000000);
+  std::string b = makeTriggerEventId("trigger-uuid-1234", 1700000001);
+  TEST_ASSERT_NOT_EQUAL(0, strcmp(a.c_str(), b.c_str()));
+}
+
+void test_make_trigger_event_id_different_triggerIds(void) {
+  std::string a = makeTriggerEventId("trigger-uuid-aaaa", 1700000000);
+  std::string b = makeTriggerEventId("trigger-uuid-bbbb", 1700000000);
+  TEST_ASSERT_NOT_EQUAL(0, strcmp(a.c_str(), b.c_str()));
+}
+
+void test_make_trigger_event_id_non_empty(void) {
+  std::string id = makeTriggerEventId("t1", 1000);
+  TEST_ASSERT_TRUE(id.length() > 0);
+}
+
+// ── Trigger enqueues on fire ──────────────────────────────────────────────────
+
+void test_trigger_evaluate_returns_fired(void) {
+  JsonDocument doc;
+  deserializeJson(doc, R"({
+    "id": "trigger-abc",
+    "enabled": true,
+    "cooldown_s": 0,
+    "condition": {"op":"literal","value":1},
+    "actions": [
+      {"type":"peripheral_action","config":{"peripheral":"relay","command":"set","value":1}}
+    ]
+  })");
+
+  Trigger t;
+  t.load(doc.as<JsonObjectConst>());
+
+  TriggerFired result = t.evaluate({}, 1234);
+
+  TEST_ASSERT_TRUE(result.fired);
+  TEST_ASSERT_EQUAL_STRING("trigger-abc", result.triggerId.c_str());
+  TEST_ASSERT_EQUAL(1234, result.firedAt);
+  TEST_ASSERT_EQUAL(1, result.actions.size());
+  TEST_ASSERT_EQUAL_STRING("relay", result.actions[0].first.c_str());
+}
+
+void test_trigger_evaluate_collects_condition_measurements(void) {
+  JsonDocument doc;
+  deserializeJson(doc, R"({
+    "id": "t1",
+    "enabled": true,
+    "cooldown_s": 0,
+    "condition": {
+      "op": "and",
+      "left":  {"op":"gt","left":{"op":"value","measurement":"temp"},"right":{"op":"literal","value":20}},
+      "right": {"op":"lt","left":{"op":"value","measurement":"ph"},"right":{"op":"literal","value":8}}
+    },
+    "actions": []
+  })");
+
+  Trigger t;
+  t.load(doc.as<JsonObjectConst>());
+
+  std::map<std::string, float> values = {
+    {"temp", 25.0f},
+    {"ph",   7.5f},
+    {"other", 99.0f}  // not in condition — must not appear in readings
+  };
+
+  TriggerFired result = t.evaluate(values, 1000);
+
+  TEST_ASSERT_TRUE(result.fired);
+  TEST_ASSERT_EQUAL(2, result.readings.size());
+  TEST_ASSERT_TRUE(result.readings.count("temp") > 0);
+  TEST_ASSERT_TRUE(result.readings.count("ph") > 0);
+  TEST_ASSERT_FALSE(result.readings.count("other") > 0);
+  TEST_ASSERT_EQUAL_FLOAT(25.0f, result.readings["temp"]);
+  TEST_ASSERT_EQUAL_FLOAT(7.5f,  result.readings["ph"]);
+}
+
+void test_trigger_not_fired_when_condition_false(void) {
+  JsonDocument doc;
+  deserializeJson(doc, R"({
+    "id": "t1",
+    "enabled": true,
+    "cooldown_s": 0,
+    "condition": {"op":"literal","value":0},
+    "actions": []
+  })");
+
+  Trigger t;
+  t.load(doc.as<JsonObjectConst>());
+
+  TriggerFired result = t.evaluate({}, 1000);
+  TEST_ASSERT_FALSE(result.fired);
+  TEST_ASSERT_EQUAL(0, result.actions.size());
+  TEST_ASSERT_EQUAL(0, result.readings.size());
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_queue_empty_on_init);
+  RUN_TEST(test_queue_push_pop);
+  RUN_TEST(test_queue_fifo_order);
+  RUN_TEST(test_queue_overflow_drops_oldest);
+
+  RUN_TEST(test_make_trigger_event_id_deterministic);
+  RUN_TEST(test_make_trigger_event_id_different_firedAt);
+  RUN_TEST(test_make_trigger_event_id_different_triggerIds);
+  RUN_TEST(test_make_trigger_event_id_non_empty);
+
+  RUN_TEST(test_trigger_evaluate_returns_fired);
+  RUN_TEST(test_trigger_evaluate_collects_condition_measurements);
+  RUN_TEST(test_trigger_not_fired_when_condition_false);
+
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- When a trigger fires (condition met + cooldown elapsed), a `TriggerEvent` is enqueued in a bounded 32-slot in-memory ring buffer (drop-oldest on overflow)
- `FishHubMqttClient::loop()` drains the queue over MQTT (`fishhub/<device_id>/trigger_events`) whenever connected; retries next loop on publish failure
- `trigger_event_id` is base64 of `"<triggerId>:<firedAt>"` — deterministic and portable, no extra library needed
- Readings in the event contain only measurements referenced by `"op":"value"` nodes in the condition tree, not every peripheral's output

## Design

`Trigger` is now a pure logic object — `evaluate()` returns a `TriggerFired` result struct with no knowledge of `PeripheralManager` or `TriggerEventQueue`. `PeripheralManager` coordinates: dispatches actions and pushes to the queue. `TriggerEventQueue` is owned in `main.cpp` and injected by reference into both.

## Test plan

- [x] `pio test -e native` — 76/76 passing (new `test_trigger_event_queue` suite + all existing suites)
- [x] `pio run` — clean ESP32 build, no warnings

Closes #78