### PR TITLE
Drain trigger event queue immediately after tickAll

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -10,11 +10,11 @@ class FishHubMqttClient {
 public:
   void begin(PeripheralManager& manager, TriggerEventQueue& eventQueue);
   void loop();
+  void drainEventQueue();
   bool publishReading(const String& payload);
 
 private:
   void connect();
-  void drainEventQueue();
   void onMessage(char* topic, byte* payload, unsigned int len);
   void onConfig(byte* payload, unsigned int len);
   void onPeripheralConfig(const String& name, byte* payload, unsigned int len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,8 @@ static void sensorTick()
   String payload = manager.tickAll(now, millis());
   if (!payload.isEmpty())
     mqttClient.publishReading(payload);
+  // Drain trigger event queue after tickAll — triggers may have fired and pushed events.
+  mqttClient.drainEventQueue();
 }
 
 // ─── state dispatch ───────────────────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,13 +137,24 @@ static void initNormalOperation()
 
 static void sensorTick()
 {
+  unsigned long t0 = millis();
   mqttClient.loop();
+  unsigned long t1 = millis();
+
   time_t now = time(nullptr);
   String payload = manager.tickAll(now, millis());
+  unsigned long t2 = millis();
+
   if (!payload.isEmpty())
     mqttClient.publishReading(payload);
-  // Drain trigger event queue after tickAll — triggers may have fired and pushed events.
+  unsigned long t3 = millis();
+
   mqttClient.drainEventQueue();
+  unsigned long t4 = millis();
+
+  if (t4-t0 > 100)
+    Serial.printf("DBG [tick timing]: loop=%lums tickAll=%lums publish=%lums drain=%lums total=%lums\n",
+                  t1-t0, t2-t1, t3-t2, t4-t3, t4-t0);
 }
 
 // ─── state dispatch ───────────────────────────────────────────────────────────

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -76,6 +76,7 @@ void FishHubMqttClient::loop() {
     unsigned long now = millis();
     if (now - _lastConnectAttempt >= RECONNECT_INTERVAL_MS) {
       _lastConnectAttempt = now;
+      Serial.printf("MQTT: disconnected (state=%d) — reconnecting\n", _client.state());
       connect();
     }
   }
@@ -109,13 +110,15 @@ void FishHubMqttClient::drainEventQueue() {
       r["value"]      = ev->readings[i].value;
     }
 
-    char payload[512];
-    serializeJson(doc, payload, sizeof(payload));
+    char payload[2048];
+    size_t payloadLen = serializeJson(doc, payload, sizeof(payload));
 
+    Serial.printf("MQTT: publishing trigger_event to '%s' (%u bytes)\n", topic, (unsigned)payloadLen);
     if (_client.publish(topic, payload, /*retained=*/false)) {
+      Serial.println("MQTT: trigger_event published OK");
       _eventQueue->pop();
     } else {
-      Serial.println("MQTT: trigger_event publish failed — will retry next loop");
+      Serial.printf("MQTT: trigger_event publish failed (state=%d) — will retry next loop\n", _client.state());
       break;
     }
   }

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -80,6 +80,7 @@ void FishHubMqttClient::loop() {
       connect();
     }
   }
+
   _client.loop();
   drainEventQueue();
 }
@@ -110,7 +111,7 @@ void FishHubMqttClient::drainEventQueue() {
       r["value"]      = ev->readings[i].value;
     }
 
-    char payload[2048];
+    char payload[512];
     size_t payloadLen = serializeJson(doc, payload, sizeof(payload));
 
     Serial.printf("MQTT: publishing trigger_event to '%s' (%u bytes)\n", topic, (unsigned)payloadLen);


### PR DESCRIPTION
## Summary

- `drainEventQueue()` was private and only called inside `loop()`, which runs *before* `tickAll()`. Events pushed during `tickAll()` were delayed one full tick before being published.
- Made `drainEventQueue()` public and call it in `sensorTick()` immediately after `tickAll()`, so events are published in the same tick they fire.
- Improved logging in `drainEventQueue()`: topic, payload size, and publish result (including MQTT state on failure) are now logged.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)