### PR TITLE
chore: remove dead pin defines from pins.h

### DIFF
--- a/include/pins.h
+++ b/include/pins.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#define ONE_WIRE_PIN       4
 #define RESET_BUTTON_PIN   0
-#define RELAY_LIGHT_PIN    16
-#define SERVO_PIN          17
 
 // Mode-toggle button for the OLED display (active HIGH, INPUT_PULLDOWN).
 // Press pulls the pin to 3.3 V; idle is LOW. Must be a pin that supports


### PR DESCRIPTION
## Summary

- Removes `ONE_WIRE_PIN`, `RELAY_LIGHT_PIN`, and `SERVO_PIN` from `include/pins.h` — none of these are referenced anywhere in the codebase
- Peripherals use dynamic pin selection, so only the two fixed-function button pins (`RESET_BUTTON_PIN`, `DISPLAY_BUTTON_PIN`) belong here

🤖 Generated with [Claude Code](https://claude.ai/claude-code)