### PR TITLE
Peripheral serialization registry

### DIFF
--- a/include/peripheral.h
+++ b/include/peripheral.h
@@ -44,4 +44,12 @@ public:
 
   // Unique name — used as MQTT topic segment and SenML field name prefix.
   virtual const char* name() const = 0;
+
+  // String constant identifying the peripheral class (e.g. "relay", "ds18b20").
+  // Derived from the class itself; never stored in PeripheralEntry.
+  virtual const char* kind() const = 0;
+
+  // User-defined label describing what this peripheral is used for.
+  // Stored at construction; no firmware logic inspects it.
+  virtual const char* purpose() const { return ""; }
 };

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -19,8 +19,7 @@ using String = std::string;
 struct PeripheralEntry {
   Peripheral* peripheral;
   uint32_t    lastTickedAt;
-  const char* kind = nullptr;
-  int         pin  = -1;
+  int         pin = -1;
 };
 
 class PeripheralManager {
@@ -28,10 +27,10 @@ public:
   // Adds a peripheral. If beginAll() has already been called, begin() is
   // invoked immediately so late-registered peripherals are initialised.
   // Ownership of the pointer is transferred — remove() will delete it.
-  void add(Peripheral* p, const char* kind = nullptr, int pin = -1);
+  void add(Peripheral* p, int pin = -1);
 
-  // Iterates all entries, calling fn(peripheral, kind, pin) for each.
-  void forEach(std::function<void(Peripheral*, const char*, int)> fn) const;
+  // Iterates all entries, calling fn(entry) for each.
+  void forEach(std::function<void(PeripheralEntry&)> fn);
   void beginAll();
 
   // Removes the peripheral with the given name and deletes the object.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripherals/relay_actuator.h"
+#include "peripheral_serializer_registry.h"
 #include "trigger.h"
 #include "trigger_event_queue.h"
 #include "button.h"
@@ -96,16 +97,14 @@ static void restorePeripherals()
     if (!name || !kind || pin < 0)
       continue;
 
-    if (strcmp(kind, "ds18b20") == 0)
+    Peripheral *peripheral = peripheralSerializerRegistry.deserialize(kind, name, p);
+    if (!peripheral)
     {
-      manager.add(new DS18B20Sensor(name, (uint8_t)pin), "ds18b20", pin);
-      Serial.printf("NVS: restored ds18b20 '%s' on pin %d\n", name, pin);
+      Serial.printf("NVS: failed to restore peripheral '%s' (kind '%s')\n", name, kind);
+      continue;
     }
-    else if (strcmp(kind, "relay") == 0)
-    {
-      manager.add(new RelayActuator(name, (uint8_t)pin), "relay", pin);
-      Serial.printf("NVS: restored relay '%s' on pin %d\n", name, pin);
-    }
+    manager.add(peripheral, pin);
+    Serial.printf("NVS: restored %s '%s' on pin %d\n", kind, name, pin);
   }
 }
 
@@ -152,6 +151,9 @@ static void restoreTriggers()
 
 static void initNormalOperation()
 {
+  peripheralSerializerRegistry.registerKind("relay",   new RelaySerializer());
+  peripheralSerializerRegistry.registerKind("ds18b20", new DS18B20Serializer());
+
   restorePeripherals();
   restoreTriggers();
   manager.beginAll();
@@ -177,8 +179,8 @@ static void sensorTick()
     // Refresh MEASUREMENTS slide data from the current peripheral snapshot
     std::vector<ReadingEntry> entries;
     std::map<std::string, float> snap;
-    manager.forEach([&snap](Peripheral *p, const char *, int)
-                    { p->currentMeasurements(snap); });
+    manager.forEach([&snap](PeripheralEntry &e)
+                    { e.peripheral->currentMeasurements(snap); });
     for (auto &kv : snap)
     {
       ReadingEntry e;

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "peripherals/relay_actuator.h"
 #include "peripherals/ds18b20_sensor.h"
+#include "peripheral_serializer_registry.h"
 #include "trigger.h"
 #include "trigger_event_queue.h"
 #include "display/oled_display.h"
@@ -262,13 +263,13 @@ static void savePeripheralsToNVS(PeripheralManager *mgr)
 {
   JsonDocument doc;
   JsonArray arr = doc.to<JsonArray>();
-  mgr->forEach([&arr](Peripheral *p, const char *kind, int pin)
-               {
-    if (!kind || pin < 0) return;
+  mgr->forEach([&arr](PeripheralEntry &e) {
     JsonObject obj = arr.add<JsonObject>();
-    obj["name"] = p->name();
-    obj["kind"] = kind;
-    obj["pin"]  = pin; });
+    obj["name"] = e.peripheral->name();
+    obj["kind"] = e.peripheral->kind();
+    obj["pin"]  = e.pin;
+    peripheralSerializerRegistry.serialize(e.peripheral, obj);
+  });
   String json;
   serializeJson(doc, json);
   nvsStore.set("peripherals", json);
@@ -430,21 +431,14 @@ void FishHubMqttClient::onPeripheralConfig(const String &name, byte *payload, un
       Serial.printf("MQTT: peripheral '%s' missing kind or pin\n", name.c_str());
       return;
     }
-    if (strcmp(kind, "relay") == 0)
+    Peripheral *p = peripheralSerializerRegistry.deserialize(kind, name.c_str(), doc.as<JsonObjectConst>());
+    if (!p)
     {
-      _manager->add(new RelayActuator(name.c_str(), (uint8_t)pin), "relay", pin);
-      Serial.printf("MQTT: registered relay '%s' on pin %d\n", name.c_str(), pin);
-    }
-    else if (strcmp(kind, "ds18b20") == 0)
-    {
-      _manager->add(new DS18B20Sensor(name.c_str(), (uint8_t)pin), "ds18b20", pin);
-      Serial.printf("MQTT: registered ds18b20 '%s' on pin %d\n", name.c_str(), pin);
-    }
-    else
-    {
-      Serial.printf("MQTT: unknown peripheral kind '%s'\n", kind);
+      Serial.printf("MQTT: unknown or invalid peripheral kind '%s'\n", kind);
       return;
     }
+    _manager->add(p, pin);
+    Serial.printf("MQTT: registered %s '%s' on pin %d\n", kind, name.c_str(), pin);
     savePeripheralsToNVS(_manager);
   }
 }

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -6,19 +6,18 @@
 // millis() not available on native — callers always inject nowMs
 #endif
 
-void PeripheralManager::add(Peripheral* p, const char* kind, int pin) {
+void PeripheralManager::add(Peripheral* p, int pin) {
   PeripheralEntry e;
   e.peripheral   = p;
   e.lastTickedAt = 0;
-  e.kind         = kind;
   e.pin          = pin;
   _entries.push_back(e);
   if (_begun) p->begin();
 }
 
-void PeripheralManager::forEach(std::function<void(Peripheral*, const char*, int)> fn) const {
-  for (const auto& e : _entries) {
-    fn(e.peripheral, e.kind, e.pin);
+void PeripheralManager::forEach(std::function<void(PeripheralEntry&)> fn) {
+  for (auto& e : _entries) {
+    fn(e);
   }
 }
 

--- a/src/peripheral_serializer_registry.cpp
+++ b/src/peripheral_serializer_registry.cpp
@@ -1,0 +1,43 @@
+#include "peripheral_serializer_registry.h"
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <cstdio>
+#define Serial_printf(...) printf(__VA_ARGS__)
+#endif
+
+PeripheralSerializerRegistry peripheralSerializerRegistry;
+
+void PeripheralSerializerRegistry::registerKind(const char* kind, PeripheralSerializer* s) {
+  if (_count >= MAX_KINDS) {
+#ifdef ARDUINO
+    Serial.printf("WARN [registry]: max kinds (%d) reached — cannot register '%s'\n", MAX_KINDS, kind);
+#endif
+    return;
+  }
+  _entries[_count++] = {kind, s};
+}
+
+void PeripheralSerializerRegistry::serialize(Peripheral* p, JsonObject& out) const {
+  for (int i = 0; i < _count; i++) {
+    if (strcmp(_entries[i].kind, p->kind()) == 0) {
+      _entries[i].serializer->serialize(p, out);
+      return;
+    }
+  }
+#ifdef ARDUINO
+  Serial.printf("WARN [registry]: no serializer for kind '%s' — skipping extra fields\n", p->kind());
+#endif
+}
+
+Peripheral* PeripheralSerializerRegistry::deserialize(const char* kind, const char* name, JsonObjectConst obj) const {
+  for (int i = 0; i < _count; i++) {
+    if (strcmp(_entries[i].kind, kind) == 0) {
+      return _entries[i].serializer->deserialize(name, obj);
+    }
+  }
+#ifdef ARDUINO
+  Serial.printf("WARN [registry]: no serializer for kind '%s' — cannot restore '%s'\n", kind, name);
+#endif
+  return nullptr;
+}

--- a/src/peripheral_serializer_registry.h
+++ b/src/peripheral_serializer_registry.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ArduinoJson.h>
+#include "peripheral.h"
+
+class PeripheralSerializer {
+public:
+  virtual ~PeripheralSerializer() = default;
+
+  // Writes kind-specific fields into `out`. `name`, `kind`, and `pin` are
+  // already written by the caller; the serializer writes everything else
+  // (purpose, sense_pin, etc.)
+  virtual void serialize(Peripheral* p, JsonObject& out) const = 0;
+
+  // Factory: reconstructs a Peripheral* from the JSON object.
+  // `name` is passed separately (written by the caller, not the serializer).
+  // Returns nullptr if required fields are missing or invalid.
+  virtual Peripheral* deserialize(const char* name, JsonObjectConst obj) const = 0;
+};
+
+class PeripheralSerializerRegistry {
+public:
+  // Takes ownership of `s`.
+  void registerKind(const char* kind, PeripheralSerializer* s);
+
+  // Looks up the serializer for p->kind() and calls serialize(p, out).
+  // Logs a warning and no-ops if no serializer is registered for that kind.
+  void serialize(Peripheral* p, JsonObject& out) const;
+
+  // Looks up the serializer for `kind` and calls deserialize(name, obj).
+  // Logs a warning and returns nullptr if no serializer is registered.
+  Peripheral* deserialize(const char* kind, const char* name, JsonObjectConst obj) const;
+
+private:
+  static constexpr int MAX_KINDS = 8;
+  struct Entry {
+    const char*          kind;
+    PeripheralSerializer* serializer;
+  };
+  Entry _entries[MAX_KINDS] = {};
+  int   _count              = 0;
+};
+
+extern PeripheralSerializerRegistry peripheralSerializerRegistry;

--- a/src/peripherals/ds18b20_sensor.cpp
+++ b/src/peripherals/ds18b20_sensor.cpp
@@ -1,8 +1,9 @@
 #include "ds18b20_sensor.h"
 #include <Arduino.h>
 
-DS18B20Sensor::DS18B20Sensor(std::string name, uint8_t pin, uint32_t intervalMs)
-  : _name(std::move(name)), _ow(pin), _sensors(&_ow), _lastTemp(0.0f), _intervalMs(intervalMs) {}
+DS18B20Sensor::DS18B20Sensor(std::string name, uint8_t pin, std::string purpose, uint32_t intervalMs)
+  : _name(std::move(name)), _purpose(std::move(purpose)), _pin(pin),
+    _ow(pin), _sensors(&_ow), _lastTemp(0.0f), _intervalMs(intervalMs) {}
 
 void DS18B20Sensor::begin() {
   _sensors.begin();

--- a/src/peripherals/ds18b20_sensor.h
+++ b/src/peripherals/ds18b20_sensor.h
@@ -4,6 +4,7 @@
 #include <OneWire.h>
 #include <DallasTemperature.h>
 #include "peripheral.h"
+#include "peripheral_serializer_registry.h"
 
 #ifndef DS18B20_INTERVAL_MS
 #define DS18B20_INTERVAL_MS 30000
@@ -11,7 +12,9 @@
 
 class DS18B20Sensor : public Peripheral {
 public:
-  DS18B20Sensor(std::string name, uint8_t pin, uint32_t intervalMs = DS18B20_INTERVAL_MS);
+  DS18B20Sensor(std::string name, uint8_t pin,
+                std::string purpose = "",
+                uint32_t intervalMs = DS18B20_INTERVAL_MS);
 
   void        begin() override;
   uint32_t    intervalMs() const override { return _intervalMs; }
@@ -19,11 +22,29 @@ public:
   void        appendSenML(JsonArray& records, time_t now) override;
   void        currentMeasurements(std::map<std::string, float>& out) const override;
   const char* name() const override { return _name.c_str(); }
+  const char* kind() const override { return "ds18b20"; }
+  const char* purpose() const override { return _purpose.c_str(); }
 
 private:
   std::string       _name;
+  std::string       _purpose;
+  uint8_t           _pin;
   OneWire           _ow;
   DallasTemperature _sensors;
   float             _lastTemp;
   uint32_t          _intervalMs;
+};
+
+class DS18B20Serializer : public PeripheralSerializer {
+public:
+  void serialize(Peripheral* p, JsonObject& out) const override {
+    out["purpose"] = p->purpose();
+  }
+
+  Peripheral* deserialize(const char* name, JsonObjectConst obj) const override {
+    int pin = obj["pin"] | -1;
+    if (pin < 0) return nullptr;
+    const char* purpose = obj["purpose"] | "";
+    return new DS18B20Sensor(name, (uint8_t)pin, purpose);
+  }
 };

--- a/src/peripherals/relay_actuator.cpp
+++ b/src/peripherals/relay_actuator.cpp
@@ -4,8 +4,8 @@
 #include "nvs_store.h"
 #endif
 
-RelayActuator::RelayActuator(std::string name, uint8_t pin)
-  : _name(std::move(name)), _pin(pin) {}
+RelayActuator::RelayActuator(std::string name, uint8_t pin, std::string purpose)
+  : _name(std::move(name)), _purpose(std::move(purpose)), _pin(pin) {}
 
 void RelayActuator::begin() {
   pinMode(_pin, OUTPUT);

--- a/src/peripherals/relay_actuator.h
+++ b/src/peripherals/relay_actuator.h
@@ -7,6 +7,7 @@
 #endif
 
 #include "peripheral.h"
+#include "peripheral_serializer_registry.h"
 #include "schedule.h"
 
 #ifndef ACTUATOR_HEARTBEAT_S
@@ -15,7 +16,7 @@
 
 class RelayActuator : public Peripheral {
 public:
-  RelayActuator(std::string name, uint8_t pin);
+  RelayActuator(std::string name, uint8_t pin, std::string purpose = "");
 
   void        begin() override;
   uint32_t    intervalMs() const override { return 1000; }
@@ -24,6 +25,8 @@ public:
   void        currentMeasurements(std::map<std::string, float>& out) const override;
   void        applyCommand(JsonObjectConst cmd) override;
   const char* name() const override { return _name.c_str(); }
+  const char* kind() const override { return "relay"; }
+  const char* purpose() const override { return _purpose.c_str(); }
 
   // Schedules are idempotent — retained messages should re-apply on reboot.
   bool replayCommand() const override { return true; }
@@ -33,9 +36,24 @@ private:
   void _restoreFromNVS();
 
   std::string _name;
+  std::string _purpose;
   uint8_t     _pin;
   Schedule    _schedule;
   bool        _currentState = false;
   bool        _lastChanged  = false;
   time_t      _lastSentAt   = 0;
+};
+
+class RelaySerializer : public PeripheralSerializer {
+public:
+  void serialize(Peripheral* p, JsonObject& out) const override {
+    out["purpose"] = p->purpose();
+  }
+
+  Peripheral* deserialize(const char* name, JsonObjectConst obj) const override {
+    int pin = obj["pin"] | -1;
+    if (pin < 0) return nullptr;
+    const char* purpose = obj["purpose"] | "";
+    return new RelayActuator(name, (uint8_t)pin, purpose);
+  }
 };

--- a/test/test_native/test_peripheral_manager.cpp
+++ b/test/test_native/test_peripheral_manager.cpp
@@ -20,6 +20,7 @@ public:
   void        begin() override {}
   uint32_t    intervalMs() const override { return _interval; }
   const char* name() const override { return _name; }
+  const char* kind() const override { return "mock"; }
 
   bool tick(time_t /*now*/) override {
     tickCount++;


### PR DESCRIPTION
## Summary

- Introduces `PeripheralSerializerRegistry` — each peripheral kind registers a `PeripheralSerializer` subclass that handles serialize/deserialize. Replaces the kind-switch pattern in `savePeripheralsToNVS` and `onPeripheralConfig`.
- Adds `kind()` (pure virtual) and `purpose()` (virtual, empty default) to the `Peripheral` interface.
- Drops `kind` from `PeripheralEntry`; `forEach` callback now receives `PeripheralEntry&` so callers read `pin` directly without it leaking through the registry interface.
- `RelaySerializer` and `DS18B20Serializer` live alongside their respective classes and are registered at startup in `initNormalOperation()`.
- Both `serialize` and `deserialize` fail gracefully — unknown kinds log a warning and no-op/return nullptr rather than crashing.

## Test plan

- [ ] `pio run` compiles without warnings
- [ ] Existing `relay` and `ds18b20` peripherals still register, persist to NVS, and restore correctly after reboot
- [ ] Unknown peripheral kind in NVS logs a warning and skips gracefully

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)