### PR TITLE
Add servo_actuator peripheral with cron trigger schedule

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ lib_deps =
   knolleary/PubSubClient @ ^2.8
   adafruit/Adafruit SSD1306 @ ^2.5.13
   adafruit/Adafruit GFX Library @ ^1.11.11
+  madhephaestus/ESP32Servo @ ^3.0.5
 
 [env:native]
 platform = native

--- a/src/cron_trigger.cpp
+++ b/src/cron_trigger.cpp
@@ -1,0 +1,55 @@
+#include "cron_trigger.h"
+#include <stdio.h>
+
+bool CronTrigger::parseCron(const char* expr) {
+  if (!expr) return false;
+
+  // Parse 5 fields: min hour dom month dow
+  int fields[5] = {-1, -1, -1, -1, -1};
+  const char* p = expr;
+
+  for (int i = 0; i < 5; i++) {
+    while (*p == ' ' || *p == '\t') p++;
+    if (*p == '\0') return false;
+
+    if (*p == '*') {
+      fields[i] = -1;
+      p++;
+    } else if (*p >= '0' && *p <= '9') {
+      fields[i] = 0;
+      while (*p >= '0' && *p <= '9') {
+        fields[i] = fields[i] * 10 + (*p - '0');
+        p++;
+      }
+    } else {
+      return false;
+    }
+
+    if (i < 4) {
+      if (*p != ' ' && *p != '\t') return false;
+      p++;
+    }
+  }
+
+  minute = fields[0];
+  hour   = fields[1];
+  dom    = fields[2];
+  month  = fields[3];
+  dow    = fields[4];
+  return true;
+}
+
+bool CronTrigger::isDue(time_t now) const {
+  struct tm* t = localtime(&now);
+  if (minute != -1 && t->tm_min        != minute) return false;
+  if (hour   != -1 && t->tm_hour       != hour)   return false;
+  if (dom    != -1 && t->tm_mday       != dom)     return false;
+  if (month  != -1 && t->tm_mon + 1    != month)   return false;
+  if (dow    != -1 && t->tm_wday       != dow)     return false;
+  time_t thisMinute = (now / 60) * 60;
+  return lastFired < thisMinute;
+}
+
+void CronTrigger::markFired(time_t now) {
+  lastFired = (now / 60) * 60;
+}

--- a/src/cron_trigger.h
+++ b/src/cron_trigger.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <time.h>
+#include <string.h>
+
+// Reusable one-shot cron trigger. Supports 5-field cron expressions
+// (min hour dom month dow) with '*' and fixed integers only.
+// Any peripheral that needs cron-based scheduling holds a vector of these.
+struct CronTrigger {
+  char   id[16];
+  int    minute;   // -1 = *
+  int    hour;     // -1 = *
+  int    dom;      // -1 = *
+  int    month;    // -1 = *
+  int    dow;      // -1 = *
+  int    value;    // peripheral-specific payload (e.g. rotation_ms)
+  time_t lastFired;
+
+  // Parses a 5-field cron expression into the fields above.
+  // Returns false if the expression is malformed.
+  bool parseCron(const char* expr);
+
+  // Returns true if the current minute matches the cron fields AND the
+  // trigger has not already fired during this occurrence.
+  // Dedup: lastFired < floor(now / 60) * 60.
+  bool isDue(time_t now) const;
+
+  // Records that the trigger fired at `now`.
+  void markFired(time_t now);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "peripheral_manager.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripherals/relay_actuator.h"
+#include "peripherals/servo_actuator.h"
 #include "peripheral_serializer_registry.h"
 #include "trigger.h"
 #include "trigger_event_queue.h"
@@ -151,8 +152,9 @@ static void restoreTriggers()
 
 static void initNormalOperation()
 {
-  peripheralSerializerRegistry.registerKind("relay",   new RelaySerializer());
-  peripheralSerializerRegistry.registerKind("ds18b20", new DS18B20Serializer());
+  peripheralSerializerRegistry.registerKind("relay",          new RelaySerializer());
+  peripheralSerializerRegistry.registerKind("ds18b20",        new DS18B20Serializer());
+  peripheralSerializerRegistry.registerKind("servo_actuator", new ServoActuatorSerializer());
 
   restorePeripherals();
   restoreTriggers();

--- a/src/peripherals/servo_actuator.cpp
+++ b/src/peripherals/servo_actuator.cpp
@@ -1,0 +1,133 @@
+#include "servo_actuator.h"
+#ifdef ARDUINO
+#include <Arduino.h>
+#include "nvs_store.h"
+#endif
+#include <ArduinoJson.h>
+
+ServoActuator::ServoActuator(const char* name, uint8_t pin,
+                             int sensePin, const char* purpose)
+  : _name(name), _purpose(purpose), _pin(pin), _sensePin(sensePin) {}
+
+void ServoActuator::begin() {
+#ifdef ARDUINO
+  if (_sensePin >= 0)
+    pinMode(_sensePin, INPUT_PULLUP);
+#endif
+}
+
+bool ServoActuator::tick(time_t now) {
+#ifdef ARDUINO
+  if (_sensePin >= 0) {
+    _senseValue   = !digitalRead(_sensePin);
+    _sensePending = true;
+  }
+#endif
+
+  for (auto& t : _triggers) {
+    if (t.isDue(now)) {
+      _actuate(t.value);
+      t.markFired(now);
+      _persistLastFired();
+    }
+  }
+
+  return _pendingRotation || _sensePending;
+}
+
+void ServoActuator::appendSenML(JsonArray& records, time_t /*now*/) {
+  if (_pendingRotation) {
+    JsonObject r = records.add<JsonObject>();
+    r["n"] = String(_name.c_str()) + "/rotation";
+    r["u"] = "ms";
+    r["v"] = _lastRotationMs;
+    _pendingRotation = false;
+  }
+  if (_sensePending) {
+    JsonObject r = records.add<JsonObject>();
+    r["n"] = String(_name.c_str()) + "/sense";
+    r["u"] = "/";
+    r["v"] = _senseValue ? 1 : 0;
+    _sensePending = false;
+  }
+}
+
+void ServoActuator::currentMeasurements(std::map<std::string, float>& out) const {
+  if (_sensePin >= 0)
+    out[_name + "/sense"] = _senseValue ? 1.0f : 0.0f;
+}
+
+void ServoActuator::applyCommand(JsonObjectConst cmd) {
+  const char* op = cmd["op"];
+  if (!op) return;
+
+  if (strcmp(op, "actuate") == 0) {
+    int rotationMs = cmd["rotation_ms"] | 500;
+    Serial.printf("ServoActuator '%s': actuate %d ms\n", _name.c_str(), rotationMs);
+    _actuate(rotationMs);
+  } else if (strcmp(op, "set_triggers") == 0) {
+    _loadTriggers(cmd["triggers"].as<JsonArrayConst>());
+  }
+}
+
+void ServoActuator::_actuate(int rotationMs) {
+#ifdef ARDUINO
+  _servo.attach(_pin);
+  _servo.writeMicroseconds(2000);
+  delay(rotationMs);
+  _servo.writeMicroseconds(1500);
+  _servo.detach();
+#endif
+  _lastRotationMs  = rotationMs;
+  _pendingRotation = true;
+}
+
+void ServoActuator::_loadTriggers(JsonArrayConst arr) {
+  _triggers.clear();
+  for (JsonObjectConst obj : arr) {
+    CronTrigger t = {};
+    const char* id   = obj["id"]   | "";
+    const char* cron = obj["cron"] | "";
+    int value        = obj["value"] | 500;
+    if (strlen(id) == 0 || !t.parseCron(cron)) {
+      Serial.printf("ServoActuator '%s': skipping invalid trigger\n", _name.c_str());
+      continue;
+    }
+    strncpy(t.id, id, sizeof(t.id) - 1);
+    t.value     = value;
+    t.lastFired = 0;
+    _triggers.push_back(t);
+  }
+  _restoreLastFired();
+}
+
+void ServoActuator::_persistLastFired() {
+#ifdef ARDUINO
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  for (auto& t : _triggers)
+    obj[t.id] = (long)t.lastFired;
+  String json;
+  serializeJson(doc, json);
+  String key = String("lf_") + _name.c_str();
+  nvsStore.set(key.c_str(), json);
+#endif
+}
+
+void ServoActuator::_restoreLastFired() {
+#ifdef ARDUINO
+  String key  = String("lf_") + _name.c_str();
+  String json = nvsStore.get(key.c_str());
+  if (json.isEmpty()) return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, json)) return;
+
+  JsonObject obj = doc.as<JsonObject>();
+  for (auto& t : _triggers) {
+    JsonVariant v = obj[t.id];
+    if (!v.isNull())
+      t.lastFired = (time_t)v.as<long>();
+  }
+#endif
+}

--- a/src/peripherals/servo_actuator.h
+++ b/src/peripherals/servo_actuator.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <ESP32Servo.h>
+#else
+#include <string>
+#endif
+
+#include <vector>
+#include <map>
+#include <string>
+#include <ArduinoJson.h>
+#include "peripheral.h"
+#include "peripheral_serializer_registry.h"
+#include "../cron_trigger.h"
+
+class ServoActuator : public Peripheral {
+public:
+  ServoActuator(const char* name, uint8_t pin,
+                int sensePin = -1, const char* purpose = "");
+
+  void        begin() override;
+  uint32_t    intervalMs() const override { return 1000; }
+  bool        tick(time_t now) override;
+  void        appendSenML(JsonArray& records, time_t now) override;
+  void        currentMeasurements(std::map<std::string, float>& out) const override;
+  void        applyCommand(JsonObjectConst cmd) override;
+  const char* name()    const override { return _name.c_str(); }
+  const char* kind()    const override { return "servo_actuator"; }
+  const char* purpose() const override { return _purpose.c_str(); }
+  int         sensePin() const         { return _sensePin; }
+
+  // One-shot — MQTT client deduplicates actuation commands by id.
+  bool replayCommand() const override { return false; }
+
+private:
+  void _actuate(int rotationMs);
+  void _persistLastFired();
+  void _restoreLastFired();
+  void _loadTriggers(JsonArrayConst arr);
+
+  std::string              _name;
+  std::string              _purpose;
+  uint8_t                  _pin;
+  int                      _sensePin;
+#ifdef ARDUINO
+  Servo                    _servo;
+#endif
+  std::vector<CronTrigger> _triggers;
+
+  bool  _pendingRotation = false;
+  int   _lastRotationMs  = 0;
+  bool  _senseValue      = false;
+  bool  _sensePending    = false;
+};
+
+class ServoActuatorSerializer : public PeripheralSerializer {
+public:
+  void serialize(Peripheral* p, JsonObject& out) const override {
+    auto* s = static_cast<ServoActuator*>(p);
+    out["sense_pin"] = s->sensePin();
+    out["purpose"]   = s->purpose();
+  }
+
+  Peripheral* deserialize(const char* name, JsonObjectConst obj) const override {
+    int pin      = obj["pin"]       | -1;
+    int sensePin = obj["sense_pin"] | -1;
+    if (pin < 0) return nullptr;
+    const char* purpose = obj["purpose"] | "";
+    return new ServoActuator(name, (uint8_t)pin, sensePin, purpose);
+  }
+};


### PR DESCRIPTION
## Summary

- Adds `CronTrigger` — a reusable one-shot cron scheduler (`src/cron_trigger.h/.cpp`). Supports 5-field specs with `*` and fixed integers. `isDue()` deduplicates within the same minute via `lastFired`; `markFired()` floors to the current minute.
- Adds `ServoActuator` — drives a continuous-rotation servo via ESP32Servo. Attaches, spins CW for `rotation_ms`, stops at 1500 µs, detaches (no heat buildup). Reads an optional IR break-beam `sense_pin` (INPUT_PULLUP, active LOW) every tick. Handles `actuate` and `set_triggers` MQTT commands.
- Adds `ServoActuatorSerializer` — serializes `sense_pin` and `purpose`; factory deserializes them. Registered via `PeripheralSerializerRegistry` — no changes to `mqtt_client.cpp` or `restorePeripherals` required.
- Adds `madhephaestus/ESP32Servo @ ^3.0.5` to `platformio.ini`.

## NVS persistence

- `last_fired` per trigger stored under `lf_<name>` as `{ "<trigger-id>": <unix-timestamp> }`.
- Restored in `_loadTriggers()` after the trigger list is populated from the broker's retained message — survives reboots without re-firing.

## Test plan

Hardware validation is tracked in issue #92.

- [ ] `pio run` compiles without warnings ✓
- [ ] Register via `{ "op": "create", "kind": "servo_actuator", "pin": 17, "sense_pin": 18, "purpose": "feeder" }`
- [ ] `actuate` with various `rotation_ms` values — verify duration and clean stop
- [ ] `servo_actuator-17/rotation` SenML record published after each actuation
- [ ] Break-beam blocked → `sense = 1`; unblocked → `sense = 0`
- [ ] Trigger schedule fires exactly once per cron occurrence; `last_fired` prevents re-fire after reboot

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)