### PR TITLE
Normalize servo applyCommand field from op to command

### DIFF
--- a/docs/peripherals.md
+++ b/docs/peripherals.md
@@ -120,6 +120,82 @@ build_flags = -DACTUATOR_HEARTBEAT_S=60
 
 ---
 
+### `ServoCR` (`src/peripherals/servo_cr.h/.cpp`)
+
+Drives a continuous-rotation servo motor on a cron-based schedule or via immediate actuation commands.
+
+| Property | Value |
+|---|---|
+| `name()` | Set at construction (e.g. `"feeder0"`) |
+| `intervalMs()` | `1000` ms |
+| `replayCommand()` | `true` — retained MQTT messages re-apply the schedule on reboot |
+
+**`applyCommand(cmd)` accepts two command shapes:**
+
+Immediate actuation:
+```json
+{ "command": "actuate", "rotation_ms": 500 }
+```
+
+Cron schedule:
+```json
+{
+  "command": "schedule",
+  "type": "cron",
+  "entries": [
+    { "id": "e1", "cron": "0 8 * * *", "value": 500 }
+  ]
+}
+```
+
+Each schedule entry fires the servo for `value` milliseconds when the cron expression matches. Sending a new schedule replaces all existing entries.
+
+SenML output on actuation:
+```json
+{"n":"feeder0/rotation","u":"ms","v":500}
+```
+
+---
+
+### `ServoPositional` (`src/peripherals/servo_positional.h/.cpp`)
+
+Drives a positional servo motor (sweeps to an angle then returns to rest) on a cron-based schedule or via immediate actuation commands.
+
+| Property | Value |
+|---|---|
+| `name()` | Set at construction (e.g. `"flap0"`) |
+| `intervalMs()` | `1000` ms |
+| `replayCommand()` | `true` — retained MQTT messages re-apply the schedule on reboot |
+
+**`applyCommand(cmd)` accepts two command shapes:**
+
+Immediate actuation:
+```json
+{ "command": "actuate", "open_angle": 120, "hold_ms": 400 }
+```
+
+Both `open_angle` and `hold_ms` are optional; they fall back to the values set at construction.
+
+Cron schedule:
+```json
+{
+  "command": "schedule",
+  "type": "cron",
+  "entries": [
+    { "id": "e1", "cron": "0 8 * * *", "value": 120 }
+  ]
+}
+```
+
+`value` is the open angle in degrees. Sending a new schedule replaces all existing entries.
+
+SenML output on actuation:
+```json
+{"n":"flap0/angle","u":"deg","v":120}
+```
+
+---
+
 ## `Schedule` (`src/schedule.h/.cpp`)
 
 Time-window–based on/off logic used by `RelayActuator`.

--- a/src/peripherals/servo_cr.cpp
+++ b/src/peripherals/servo_cr.cpp
@@ -57,16 +57,16 @@ void ServoCR::currentMeasurements(std::map<std::string, float>& out) const {
 }
 
 void ServoCR::applyCommand(JsonObjectConst cmd) {
-  const char* op = cmd["op"];
-  if (!op) return;
+  const char* command = cmd["command"];
+  if (!command) return;
 
-  if (strcmp(op, "actuate") == 0) {
+  if (strcmp(command, "actuate") == 0) {
     int rotationMs = cmd["rotation_ms"] | 500;
 #ifdef ARDUINO
     Serial.printf("ServoCR '%s': actuate %d ms\n", _name.c_str(), rotationMs);
 #endif
     _actuate(rotationMs);
-  } else if (strcmp(op, "schedule") == 0) {
+  } else if (strcmp(command, "schedule") == 0) {
     const char* type = cmd["type"] | "windows";
     if (strcmp(type, "cron") == 0)
       _loadEntries(cmd["entries"].as<JsonArrayConst>());

--- a/src/peripherals/servo_positional.cpp
+++ b/src/peripherals/servo_positional.cpp
@@ -61,10 +61,10 @@ void ServoPositional::currentMeasurements(std::map<std::string, float>& out) con
 }
 
 void ServoPositional::applyCommand(JsonObjectConst cmd) {
-  const char* op = cmd["op"];
-  if (!op) return;
+  const char* command = cmd["command"];
+  if (!command) return;
 
-  if (strcmp(op, "actuate") == 0) {
+  if (strcmp(command, "actuate") == 0) {
     int openAngle = cmd["open_angle"] | _openAngle;
     int holdMs    = cmd["hold_ms"]    | _holdMs;
 #ifdef ARDUINO
@@ -72,7 +72,7 @@ void ServoPositional::applyCommand(JsonObjectConst cmd) {
                   _name.c_str(), openAngle, holdMs);
 #endif
     _actuate(openAngle, holdMs);
-  } else if (strcmp(op, "schedule") == 0) {
+  } else if (strcmp(command, "schedule") == 0) {
     const char* type = cmd["type"] | "windows";
     if (strcmp(type, "cron") == 0)
       _loadEntries(cmd["entries"].as<JsonArrayConst>());

--- a/test/test_servo_cr/test_servo_cr.cpp
+++ b/test/test_servo_cr/test_servo_cr.cpp
@@ -13,7 +13,7 @@ void test_actuate_sets_pending_rotation(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"]          = "actuate";
+  cmd["command"]          = "actuate";
   cmd["rotation_ms"] = 1200;
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
@@ -38,7 +38,7 @@ void test_append_senml_clears_pending(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"]          = "actuate";
+  cmd["command"]          = "actuate";
   cmd["rotation_ms"] = 500;
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
@@ -58,7 +58,7 @@ void test_unknown_op_ignored(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "reboot";
+  cmd["command"] = "reboot";
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
   JsonDocument doc;
@@ -72,7 +72,7 @@ void test_sense_emitted_when_pending(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"]          = "actuate";
+  cmd["command"]          = "actuate";
   cmd["rotation_ms"] = 300;
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
@@ -98,7 +98,7 @@ void test_schedule_cron_entry_fires_when_due(void) {
   snprintf(cron, sizeof(cron), "%d %d * * *", t->tm_min, t->tm_hour);
 
   JsonDocument cmd;
-  cmd["op"]   = "schedule";
+  cmd["command"]   = "schedule";
   cmd["type"] = "cron";
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
@@ -134,7 +134,7 @@ void test_schedule_cron_entry_does_not_refire_same_minute(void) {
   snprintf(cron, sizeof(cron), "%d %d * * *", t->tm_min, t->tm_hour);
 
   JsonDocument cmd;
-  cmd["op"]   = "schedule";
+  cmd["command"]   = "schedule";
   cmd["type"] = "cron";
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
@@ -160,7 +160,7 @@ void test_schedule_cron_type_missing_defaults_to_windows_noop(void) {
 
   // Missing type — should not load cron entries, no crash
   JsonDocument cmd;
-  cmd["op"] = "schedule";
+  cmd["command"] = "schedule";
   // no "type" field
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
@@ -184,7 +184,7 @@ void test_schedule_replace_clears_entries_for_removed_ids(void) {
 
   // Load e1 — should fire at T0
   JsonDocument cmd1;
-  cmd1["op"]   = "schedule";
+  cmd1["command"]   = "schedule";
   cmd1["type"] = "cron";
   JsonArray e1 = cmd1["entries"].to<JsonArray>();
   JsonObject en1 = e1.add<JsonObject>();
@@ -196,7 +196,7 @@ void test_schedule_replace_clears_entries_for_removed_ids(void) {
 
   // Replace with e2 only — e1 is gone, e2 has a non-matching cron so nothing fires
   JsonDocument cmd2;
-  cmd2["op"]   = "schedule";
+  cmd2["command"]   = "schedule";
   cmd2["type"] = "cron";
   JsonArray e2 = cmd2["entries"].to<JsonArray>();
   JsonObject en2 = e2.add<JsonObject>();

--- a/test/test_servo_positional/test_servo_positional.cpp
+++ b/test/test_servo_positional/test_servo_positional.cpp
@@ -13,7 +13,7 @@ void test_actuate_explicit_angle(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"]         = "actuate";
+  cmd["command"]         = "actuate";
   cmd["open_angle"] = 90;
   cmd["hold_ms"]    = 600;
   servo.applyCommand(cmd.as<JsonObjectConst>());
@@ -39,7 +39,7 @@ void test_actuate_defaults_to_construction_angle(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "actuate";
+  cmd["command"] = "actuate";
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
   JsonDocument doc;
@@ -59,7 +59,7 @@ void test_actuate_defaults_to_construction_hold_ms(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"]         = "actuate";
+  cmd["command"]         = "actuate";
   cmd["open_angle"] = 45;
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
@@ -80,7 +80,7 @@ void test_append_senml_clears_pending(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "actuate";
+  cmd["command"] = "actuate";
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
   JsonDocument doc1;
@@ -99,7 +99,7 @@ void test_unknown_op_ignored(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "reboot";
+  cmd["command"] = "reboot";
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
   JsonDocument doc;
@@ -113,7 +113,7 @@ void test_sense_record_when_pending(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "actuate";
+  cmd["command"] = "actuate";
   servo.applyCommand(cmd.as<JsonObjectConst>());
 
   JsonDocument doc;
@@ -140,7 +140,7 @@ void test_schedule_cron_entry_fires_when_due(void) {
   snprintf(cron, sizeof(cron), "%d %d * * *", t->tm_min, t->tm_hour);
 
   JsonDocument cmd;
-  cmd["op"]   = "schedule";
+  cmd["command"]   = "schedule";
   cmd["type"] = "cron";
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
@@ -176,7 +176,7 @@ void test_schedule_cron_entry_does_not_refire_same_minute(void) {
   snprintf(cron, sizeof(cron), "%d %d * * *", t->tm_min, t->tm_hour);
 
   JsonDocument cmd;
-  cmd["op"]   = "schedule";
+  cmd["command"]   = "schedule";
   cmd["type"] = "cron";
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
@@ -198,7 +198,7 @@ void test_schedule_cron_type_missing_defaults_to_windows_noop(void) {
   servo.begin();
 
   JsonDocument cmd;
-  cmd["op"] = "schedule";
+  cmd["command"] = "schedule";
   JsonArray entries = cmd["entries"].to<JsonArray>();
   JsonObject entry  = entries.add<JsonObject>();
   entry["id"]    = "e1";


### PR DESCRIPTION
## Summary

- `ServoCR` and `ServoPositional` were reading `cmd["op"]` in `applyCommand` while `RelayActuator` reads `cmd["command"]` — all actuators now use the same field
- Updated all test fixtures in `test_servo_cr` and `test_servo_positional` to send `cmd["command"]` instead of `cmd["op"]`
- Added `ServoCR` and `ServoPositional` command shape documentation to `docs/peripherals.md`

## Test plan

- [x] `pio test -e native` — 93/93 passed
- [x] `pio run` — clean build, no warnings

Closes #100