### PR TITLE
feat: compile-time firmware version + retained status reporting

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -14,6 +14,7 @@ public:
   void loop();
   void drainEventQueue();
   bool publishReading(const String& payload);
+  void publishStatus(const char* lastUpdateResult = nullptr);
 
 private:
   void connect();

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION "0.0.0-dev"
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,8 @@ platform      = espressif32
 board         = nodemcu-32s
 framework     = arduino
 monitor_speed = 115200
+; FIRMWARE_VERSION is injected by CI: -D FIRMWARE_VERSION='"X.Y.Z"'
+; Local builds fall back to "0.0.0-dev" (defined in include/version.h).
 lib_deps =
   paulstoffregen/OneWire @ ^2.3.8
   milesburton/DallasTemperature @ ^3.11.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include "pins.h"
+#include "version.h"
 #include "nvs_store.h"
 #include "provisioning.h"
 #include "wifi_ntp.h"
@@ -254,7 +255,7 @@ static void runState()
 void setup()
 {
   Serial.begin(115200);
-  Serial.println("FishHub firmware booting...");
+  Serial.printf("FishHub firmware booting — version %s\n", FIRMWARE_VERSION);
   nvsStore.begin();
   pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
   pinMode(DISPLAY_BUTTON_PIN, INPUT_PULLDOWN);

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -1,6 +1,7 @@
 #include "mqtt_client.h"
 #include "nvs_store.h"
 #include "config.h"
+#include "version.h"
 #include "peripherals/relay_actuator.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripheral_serializer_registry.h"
@@ -171,6 +172,8 @@ void FishHubMqttClient::connect()
   _client.subscribe(configTopic.c_str());
   _client.subscribe(triggersTopic.c_str());
   Serial.printf("MQTT: connected, subscribed to commands, peripherals, config and triggers topics\n");
+
+  publishStatus();
 }
 
 void FishHubMqttClient::onMessage(char *topic, byte *payload, unsigned int len)
@@ -366,6 +369,24 @@ bool FishHubMqttClient::publishReading(const String &payload)
     }
   }
   return ok;
+}
+
+void FishHubMqttClient::publishStatus(const char *lastUpdateResult)
+{
+  if (!_client.connected())
+    return;
+
+  JsonDocument doc;
+  doc["firmware_version"] = FIRMWARE_VERSION;
+  if (lastUpdateResult && strlen(lastUpdateResult) > 0)
+    doc["last_update_result"] = lastUpdateResult;
+
+  char payload[128];
+  size_t len = serializeJson(doc, payload, sizeof(payload));
+
+  String topic = "fishhub/" + _deviceId + "/status";
+  bool ok = _client.publish(topic.c_str(), (const uint8_t *)payload, len, /*retained=*/true);
+  Serial.printf("MQTT: publishStatus %s (%s)\n", payload, ok ? "OK" : "FAILED");
 }
 
 void FishHubMqttClient::onConfig(byte *payload, unsigned int len)


### PR DESCRIPTION
## Summary

- Adds `include/version.h` with `FIRMWARE_VERSION` defaulting to `"0.0.0-dev"` for local builds; CI will override it via `-D FIRMWARE_VERSION='"X.Y.Z"'` at build time (documented in `platformio.ini`).
- Logs the version over Serial at boot: `FishHub firmware booting — version X.Y.Z`.
- Publishes a **retained** `fishhub/<device_id>/status` message with `{"firmware_version": "..."}` on every MQTT (re)connect via the new `FishHubMqttClient::publishStatus()`.
- `publishStatus()` accepts an optional `last_update_result` field so OTA phases (3.3) can report update outcomes without changing the topic shape.

## Test plan

- [ ] `pio run -e nodemcu-32s` compiles cleanly (no tag → uses `0.0.0-dev`)
- [ ] `pio test -e native` — all 93 tests pass
- [ ] After flashing, Serial shows the version at boot
- [ ] `mosquitto_sub -t 'fishhub/<id>/status' -v` receives the retained payload with correct version after connect/reconnect

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)