### PR TITLE
feat: OTA flash, SHA-256 verification, and NVS-based rollback

### DIFF
--- a/include/ota_update.h
+++ b/include/ota_update.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Downloads the firmware binary at `url` over HTTPS (TLS without CA verification —
+// integrity is guaranteed by the sha256 comparison, not the cert chain), writes it
+// to the inactive OTA slot, and verifies the SHA-256.
+//
+// Returns true on success — the caller is responsible for setting the NVS rollback
+// guards and rebooting. Returns false on any error (HTTP failure, write error, hash
+// mismatch); the OTA slot is aborted and the current firmware is unaffected.
+bool performOtaUpdate(const String& url, const String& expectedSha256);

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,7 @@ platform      = espressif32
 board         = nodemcu-32s
 framework     = arduino
 monitor_speed = 115200
+board_build.partitions = default.csv
 ; FIRMWARE_VERSION is injected by CI: -D FIRMWARE_VERSION='"X.Y.Z"'
 ; Local builds fall back to "0.0.0-dev" (defined in include/version.h).
 lib_deps =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,9 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include <esp_ota_ops.h>
 #include "pins.h"
 #include "version.h"
+#include "ota_update.h"
 #include "nvs_store.h"
 #include "provisioning.h"
 #include "wifi_ntp.h"
@@ -25,6 +27,7 @@ enum class State
   CONNECT_WIFI,
   NTP_SYNC,
   NORMAL_OPERATION,
+  UPDATE_FIRMWARE,
   ERROR_RETRY,
 };
 
@@ -47,6 +50,8 @@ static const char *stateName(State s)
     return "NTP_SYNC";
   case State::NORMAL_OPERATION:
     return "NORMAL_OPERATION";
+  case State::UPDATE_FIRMWARE:
+    return "UPDATE_FIRMWARE";
   case State::ERROR_RETRY:
     return "ERROR_RETRY";
   }
@@ -69,6 +74,74 @@ static void enterErrorRetry(State next, const char *reason)
   errorRetryUntil = millis() + ERROR_RETRY_DELAY_MS;
   errorNextState = next;
   setState(State::ERROR_RETRY);
+}
+
+// ─── OTA update ───────────────────────────────────────────────────────────────
+
+static const int OTA_MAX_BOOT_ATTEMPTS = 3;
+
+struct OtaParams { String url; String sha256; };
+static OtaParams pendingOta;
+
+static void startOtaUpdate(const String& url, const String& sha256) {
+  pendingOta = {url, sha256};
+  setState(State::UPDATE_FIRMWARE);
+}
+
+// Called early in setup() — rolls back to the previous OTA slot if the new
+// firmware has failed to confirm healthy (MQTT connect) within the allowed boots.
+static void checkOtaRollback() {
+  if (nvsStore.get("fw_pending") != "1") return;
+
+  int count = nvsStore.get("fw_boot_count").toInt() + 1;
+  Serial.printf("[OTA] Boot attempt %d/%d after update\n", count, OTA_MAX_BOOT_ATTEMPTS);
+
+  if (count < OTA_MAX_BOOT_ATTEMPTS) {
+    nvsStore.set("fw_boot_count", String(count));
+    return;
+  }
+
+  Serial.println("[OTA] Max boot attempts reached — rolling back");
+  String prevLabel = nvsStore.get("fw_prev_part");
+  nvsStore.remove("fw_pending");
+  nvsStore.remove("fw_boot_count");
+  nvsStore.remove("fw_prev_part");
+
+  if (!prevLabel.isEmpty()) {
+    const esp_partition_t* prev = esp_partition_find_first(
+        ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_ANY, prevLabel.c_str());
+    if (prev) {
+      esp_ota_set_boot_partition(prev);
+      Serial.println("[OTA] Rebooting into previous firmware");
+      delay(100);
+      ESP.restart();
+    }
+  }
+  Serial.println("[OTA] Rollback failed — previous partition not found");
+}
+
+static void runUpdateFirmware() {
+  Serial.println("[OTA] Entering UPDATE_FIRMWARE state");
+
+  // Save the current partition label for rollback before touching anything.
+  const esp_partition_t* current = esp_ota_get_running_partition();
+
+  bool ok = performOtaUpdate(pendingOta.url, pendingOta.sha256);
+
+  if (!ok) {
+    Serial.println("[OTA] Update failed — returning to NORMAL_OPERATION");
+    setState(State::NORMAL_OPERATION);
+    return;
+  }
+
+  // Flash succeeded. Set rollback guards before rebooting so the new firmware
+  // must confirm health (MQTT connect) within OTA_MAX_BOOT_ATTEMPTS boots.
+  nvsStore.set("fw_prev_part", String(current->label));
+  nvsStore.set("fw_pending",   "1");
+  nvsStore.set("fw_boot_count","0");
+  Serial.println("[OTA] Rebooting into new firmware");
+  delay(500);
+  ESP.restart();
 }
 
 // ─── normal operation helpers ─────────────────────────────────────────────────
@@ -165,6 +238,14 @@ static void initNormalOperation()
   manager.setEventQueue(eventQueue);
   mqttClient.begin(manager, eventQueue);
   normalOperationInitDone = true;
+
+  // Test hook: define OTA_TEST_URL and OTA_TEST_SHA256 as build flags to
+  // trigger a one-shot OTA on first boot into NORMAL_OPERATION. Removed in 3.3
+  // when the MQTT manifest replaces this path.
+#if defined(OTA_TEST_URL) && defined(OTA_TEST_SHA256)
+  Serial.println("[OTA] Test trigger: starting update from compile-time URL");
+  startOtaUpdate(OTA_TEST_URL, OTA_TEST_SHA256);
+#endif
 }
 
 static void sensorTick()
@@ -243,6 +324,10 @@ static void runState()
     sensorTick();
     break;
 
+  case State::UPDATE_FIRMWARE:
+    runUpdateFirmware();
+    break;
+
   case State::ERROR_RETRY:
     if (millis() >= errorRetryUntil)
       setState(errorNextState);
@@ -257,6 +342,7 @@ void setup()
   Serial.begin(115200);
   Serial.printf("FishHub firmware booting — version %s\n", FIRMWARE_VERSION);
   nvsStore.begin();
+  checkOtaRollback();
   pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
   pinMode(DISPLAY_BUTTON_PIN, INPUT_PULLDOWN);
   oledDisplay.begin();

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -175,6 +175,14 @@ void FishHubMqttClient::connect()
   _client.subscribe(triggersTopic.c_str());
   Serial.printf("MQTT: connected, subscribed to commands, peripherals, config and triggers topics\n");
 
+  // Confirm OTA health — new firmware reached MQTT connect, so it's good.
+  if (nvsStore.get("fw_pending") == "1") {
+    nvsStore.remove("fw_pending");
+    nvsStore.remove("fw_boot_count");
+    nvsStore.remove("fw_prev_part");
+    Serial.println("[OTA] Firmware validated — MQTT connected");
+  }
+
   publishStatus();
 }
 

--- a/src/ota_update.cpp
+++ b/src/ota_update.cpp
@@ -1,0 +1,102 @@
+#include "ota_update.h"
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <Update.h>
+#include <mbedtls/sha256.h>
+
+static const int    OTA_CONNECT_TIMEOUT_MS = 30000;
+static const int    OTA_READ_TIMEOUT_S     = 30;
+static const size_t OTA_BUF_SIZE           = 4096;
+
+bool performOtaUpdate(const String& url, const String& expectedSha256) {
+    Serial.printf("[OTA] Downloading from %s\n", url.c_str());
+
+    WiFiClientSecure client;
+    client.setInsecure(); // TLS without CA verification — sha256 is the integrity check
+
+    HTTPClient http;
+    http.begin(client, url);
+    http.setTimeout(OTA_CONNECT_TIMEOUT_MS);
+
+    int code = http.GET();
+    if (code != HTTP_CODE_OK) {
+        Serial.printf("[OTA] HTTP error: %d\n", code);
+        http.end();
+        return false;
+    }
+
+    int contentLen = http.getSize(); // -1 if server omits Content-Length
+    Serial.printf("[OTA] Content-Length: %d bytes\n", contentLen);
+
+    if (!Update.begin(contentLen > 0 ? (size_t)contentLen : UPDATE_SIZE_UNKNOWN)) {
+        Serial.printf("[OTA] Update.begin failed: %s\n", Update.errorString());
+        http.end();
+        return false;
+    }
+
+    mbedtls_sha256_context sha;
+    mbedtls_sha256_init(&sha);
+    mbedtls_sha256_starts(&sha, /*is224=*/0);
+
+    WiFiClient* stream = http.getStreamPtr();
+    stream->setTimeout(OTA_READ_TIMEOUT_S);
+
+    static uint8_t buf[OTA_BUF_SIZE];
+    int remaining = contentLen; // negative means unknown
+    int totalWritten = 0;
+    bool error = false;
+
+    while ((remaining != 0) && http.connected() && !error) {
+        int toRead = (remaining > 0)
+            ? min(remaining, (int)sizeof(buf))
+            : (int)sizeof(buf);
+
+        int n = stream->readBytes(buf, toRead);
+        if (n <= 0) break; // timeout or connection closed
+
+        mbedtls_sha256_update(&sha, buf, n);
+
+        if (Update.write(buf, n) != (size_t)n) {
+            Serial.println("[OTA] Flash write error");
+            error = true;
+            break;
+        }
+
+        totalWritten += n;
+        if (remaining > 0) remaining -= n;
+    }
+
+    http.end();
+
+    if (error || (contentLen > 0 && totalWritten < contentLen)) {
+        Serial.printf("[OTA] Incomplete: received %d of %d bytes\n", totalWritten, contentLen);
+        Update.abort();
+        mbedtls_sha256_free(&sha);
+        return false;
+    }
+
+    // Verify SHA-256
+    uint8_t digest[32];
+    mbedtls_sha256_finish(&sha, digest);
+    mbedtls_sha256_free(&sha);
+
+    char hex[65];
+    for (int i = 0; i < 32; i++) snprintf(&hex[i * 2], 3, "%02x", digest[i]);
+    hex[64] = '\0';
+
+    if (!expectedSha256.isEmpty() && String(hex) != expectedSha256) {
+        Serial.printf("[OTA] SHA-256 mismatch\n  got:      %s\n  expected: %s\n",
+                      hex, expectedSha256.c_str());
+        Update.abort();
+        return false;
+    }
+    Serial.printf("[OTA] SHA-256 verified: %s\n", hex);
+
+    if (!Update.end(/*evenIfRemaining=*/true)) {
+        Serial.printf("[OTA] Update.end failed: %s\n", Update.errorString());
+        return false;
+    }
+
+    Serial.printf("[OTA] Flash complete — %d bytes written\n", totalWritten);
+    return true;
+}


### PR DESCRIPTION
## Summary

- Adds `UPDATE_FIRMWARE` state that downloads firmware over HTTPS, verifies SHA-256, and writes it to the inactive OTA slot via the Arduino `Update` library
- On success, sets NVS rollback guards (`fw_pending`, `fw_boot_count`, `fw_prev_part`) and reboots; if MQTT fails to connect within 3 boot attempts, rolls back to the previous slot via `esp_ota_set_boot_partition()`
- `OTA_TEST_URL` / `OTA_TEST_SHA256` compile-time flags trigger a one-shot update on first NORMAL_OPERATION entry (removed in issue 3.3)
- Made `board_build.partitions = default.csv` explicit (`default.csv` already has `app0`/`app1` OTA slots — no flash erase needed)

## Test plan

- [x] `pio run -e nodemcu-32s` — clean build, 85.2% flash usage (fits in the 1.25 MB OTA slot)
- [x] `pio test -e native` — 93/93 tests passed
- [ ] Hardware: flash with `OTA_TEST_URL` + `OTA_TEST_SHA256` pointing at the v0.1.1 bin from Railway Bucket; confirm update completes, SHA-256 verified, device reboots and reconnects MQTT, NVS rollback flags cleared

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)