### PR TITLE
feat: consume firmware manifest, safe-point OTA gate

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -16,12 +16,20 @@ public:
   bool publishReading(const String& payload);
   void publishStatus(const char* lastUpdateResult = nullptr);
 
+  // Returns true if a newer firmware manifest has been received and not yet processed.
+  bool          hasPendingUpdate()      const { return _hasPendingUpdate; }
+  const String& pendingUpdateUrl()      const { return _pendingUpdateUrl; }
+  const String& pendingUpdateSha256()   const { return _pendingUpdateSha256; }
+  const String& pendingUpdateNonce()    const { return _pendingUpdateNonce; }
+  void          clearPendingUpdate()          { _hasPendingUpdate = false; }
+
 private:
   void connect();
   void onMessage(char* topic, byte* payload, unsigned int len);
   void onConfig(byte* payload, unsigned int len);
   void onPeripheralConfig(const String& name, byte* payload, unsigned int len);
   void onTriggerConfig(const String& id, byte* payload, unsigned int len);
+  void onFirmwareManifest(byte* payload, unsigned int len);
 
 #ifdef MQTT_TLS
   WiFiClientSecure    _tlsClient;
@@ -37,4 +45,9 @@ private:
   String              _mqttHost;
   uint16_t            _mqttPort           = 8883;
   unsigned long       _lastConnectAttempt = 0;
+
+  bool                _hasPendingUpdate   = false;
+  String              _pendingUpdateUrl;
+  String              _pendingUpdateSha256;
+  String              _pendingUpdateNonce;
 };

--- a/include/peripheral.h
+++ b/include/peripheral.h
@@ -31,6 +31,10 @@ public:
   // Entry point for inbound MQTT commands. Sensors may leave this as the default no-op.
   virtual void applyCommand(JsonObjectConst cmd) {}
 
+  // Returns true while the peripheral has an actuation in progress or uncommitted state
+  // that should be reported before a reboot. Used as a safe-point gate for OTA updates.
+  virtual bool isBusy() const { return false; }
+
   // Returns true if retained/redelivered commands should always be re-applied (default).
   // Idempotent peripherals (schedules, state) return true.
   // One-shot peripherals (feeder, doser) override to false — the MQTT client will

--- a/include/peripheral_manager.h
+++ b/include/peripheral_manager.h
@@ -62,6 +62,9 @@ public:
   // Iterates all triggers, calling fn(trigger) for each.
   void forEachTrigger(std::function<void(Trigger*)> fn) const;
 
+  // Returns true if any registered peripheral has isBusy() == true.
+  bool anyBusy() const;
+
   // Injects the event queue. Must be called before tickAll if triggers are used.
   void setEventQueue(TriggerEventQueue& queue) { _eventQueue = &queue; }
 

--- a/include/semver.h
+++ b/include/semver.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stddef.h>
+
+// Returns true if version string `a` is strictly greater than `b`.
+// Both must be "X.Y.Z" format. Non-conforming strings compare as equal (returns false).
+inline bool semverGreater(const char* a, const char* b) {
+    int aMaj = 0, aMin = 0, aPat = 0;
+    int bMaj = 0, bMin = 0, bPat = 0;
+    if (sscanf(a, "%d.%d.%d", &aMaj, &aMin, &aPat) != 3) return false;
+    if (sscanf(b, "%d.%d.%d", &bMaj, &bMin, &bPat) != 3) return false;
+    if (aMaj != bMaj) return aMaj > bMaj;
+    if (aMin != bMin) return aMin > bMin;
+    return aPat > bPat;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,9 @@ static void enterErrorRetry(State next, const char *reason)
   setState(State::ERROR_RETRY);
 }
 
+// Forward declaration — mqttClient is defined in the normal operation section below.
+static FishHubMqttClient mqttClient;
+
 // ─── OTA update ───────────────────────────────────────────────────────────────
 
 static const int OTA_MAX_BOOT_ATTEMPTS = 3;
@@ -130,6 +133,7 @@ static void runUpdateFirmware() {
 
   if (!ok) {
     Serial.println("[OTA] Update failed — returning to NORMAL_OPERATION");
+    mqttClient.publishStatus("failed:flash");
     setState(State::NORMAL_OPERATION);
     return;
   }
@@ -147,7 +151,6 @@ static void runUpdateFirmware() {
 // ─── normal operation helpers ─────────────────────────────────────────────────
 
 static PeripheralManager manager;
-static FishHubMqttClient mqttClient;
 static TriggerEventQueue eventQueue;
 static bool normalOperationInitDone = false;
 
@@ -238,20 +241,26 @@ static void initNormalOperation()
   manager.setEventQueue(eventQueue);
   mqttClient.begin(manager, eventQueue);
   normalOperationInitDone = true;
-
-  // Test hook: define OTA_TEST_URL and OTA_TEST_SHA256 as build flags to
-  // trigger a one-shot OTA on first boot into NORMAL_OPERATION. Removed in 3.3
-  // when the MQTT manifest replaces this path.
-#if defined(OTA_TEST_URL) && defined(OTA_TEST_SHA256)
-  Serial.println("[OTA] Test trigger: starting update from compile-time URL");
-  startOtaUpdate(OTA_TEST_URL, OTA_TEST_SHA256);
-#endif
 }
 
 static void sensorTick()
 {
   unsigned long t0 = millis();
   mqttClient.loop();
+
+  // Safe-point gate: trigger OTA only when no peripheral has uncommitted state
+  // and the trigger event queue is fully drained.
+  if (mqttClient.hasPendingUpdate() && !manager.anyBusy() && eventQueue.empty()) {
+    String url    = mqttClient.pendingUpdateUrl();
+    String sha256 = mqttClient.pendingUpdateSha256();
+    String nonce  = mqttClient.pendingUpdateNonce();
+    mqttClient.clearPendingUpdate();
+    // Persist nonce before flashing so a failed flash doesn't re-trigger on reboot.
+    nvsStore.set("fw_nonce", nonce);
+    mqttClient.publishStatus("updating");
+    startOtaUpdate(url, sha256);
+    return;
+  }
   unsigned long t1 = millis();
 
   time_t now = time(nullptr);

--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -2,6 +2,7 @@
 #include "nvs_store.h"
 #include "config_defaults.h"
 #include "version.h"
+#include "semver.h"
 #include "peripherals/relay_actuator.h"
 #include "peripherals/ds18b20_sensor.h"
 #include "peripheral_serializer_registry.h"
@@ -169,11 +170,13 @@ void FishHubMqttClient::connect()
   String peripheralsTopic = "fishhub/" + _deviceId + "/peripherals/#";
   String configTopic = "fishhub/" + _deviceId + "/config";
   String triggersTopic = "fishhub/" + _deviceId + "/triggers/#";
+  String firmwareTopic = "fishhub/" + _deviceId + "/firmware";
   _client.subscribe(cmdTopic.c_str());
   _client.subscribe(peripheralsTopic.c_str());
   _client.subscribe(configTopic.c_str());
   _client.subscribe(triggersTopic.c_str());
-  Serial.printf("MQTT: connected, subscribed to commands, peripherals, config and triggers topics\n");
+  _client.subscribe(firmwareTopic.c_str());
+  Serial.printf("MQTT: connected, subscribed to commands, peripherals, config, triggers and firmware topics\n");
 
   // Confirm OTA health — new firmware reached MQTT connect, so it's good.
   if (nvsStore.get("fw_pending") == "1") {
@@ -181,6 +184,8 @@ void FishHubMqttClient::connect()
     nvsStore.remove("fw_boot_count");
     nvsStore.remove("fw_prev_part");
     Serial.println("[OTA] Firmware validated — MQTT connected");
+    publishStatus("ok");
+    return; // publishStatus already called; skip the default call below
   }
 
   publishStatus();
@@ -198,6 +203,12 @@ void FishHubMqttClient::onMessage(char *topic, byte *payload, unsigned int len)
   if (rest == "config")
   {
     onConfig(payload, len);
+    return;
+  }
+
+  if (rest == "firmware")
+  {
+    onFirmwareManifest(payload, len);
     return;
   }
 
@@ -520,4 +531,50 @@ void FishHubMqttClient::onTriggerConfig(const String &id, byte *payload, unsigne
   }
 
   Serial.printf("MQTT: unknown op '%s' on triggers/%s\n", op, id.c_str());
+}
+
+void FishHubMqttClient::onFirmwareManifest(byte* payload, unsigned int len)
+{
+  if (len == 0)
+    return;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, payload, len))
+  {
+    Serial.println("[OTA] Bad JSON on firmware topic — ignored");
+    return;
+  }
+
+  const char* version = doc["version"];
+  const char* url     = doc["url"];
+  const char* sha256  = doc["sha256"];
+  const char* nonce   = doc["nonce"];
+
+  if (!version || !url || !sha256 || !nonce)
+  {
+    Serial.println("[OTA] Firmware manifest missing required fields — ignored");
+    return;
+  }
+
+  // Nonce dedup: ignore if we already processed this nonce.
+  String storedNonce = nvsStore.get("fw_nonce");
+  if (storedNonce == nonce)
+  {
+    Serial.printf("[OTA] Manifest nonce %s already processed — ignored\n", nonce);
+    return;
+  }
+
+  // Semver check: ignore if the manifest version is not newer than current.
+  if (!semverGreater(version, FIRMWARE_VERSION))
+  {
+    Serial.printf("[OTA] Manifest version %s is not newer than current %s — ignored\n",
+                  version, FIRMWARE_VERSION);
+    return;
+  }
+
+  Serial.printf("[OTA] Newer firmware available: %s (current: %s)\n", version, FIRMWARE_VERSION);
+  _pendingUpdateUrl    = String(url);
+  _pendingUpdateSha256 = String(sha256);
+  _pendingUpdateNonce  = String(nonce);
+  _hasPendingUpdate    = true;
 }

--- a/src/peripheral_manager.cpp
+++ b/src/peripheral_manager.cpp
@@ -155,3 +155,10 @@ Trigger* PeripheralManager::findTrigger(const std::string& id) const {
 void PeripheralManager::forEachTrigger(std::function<void(Trigger*)> fn) const {
   for (auto* t : _triggers) fn(t);
 }
+
+bool PeripheralManager::anyBusy() const {
+  for (const auto& e : _entries) {
+    if (e.peripheral->isBusy()) return true;
+  }
+  return false;
+}

--- a/src/peripherals/servo_cr.h
+++ b/src/peripherals/servo_cr.h
@@ -32,6 +32,7 @@ public:
   int         sensePin() const         { return _sensePin; }
 
   bool replayCommand() const override { return false; }
+  bool isBusy()        const override { return _pendingRotation || _sensePending; }
 
 private:
   void _actuate(int rotationMs);

--- a/src/peripherals/servo_positional.h
+++ b/src/peripherals/servo_positional.h
@@ -39,6 +39,7 @@ public:
   int         holdMs()    const          { return _holdMs; }
 
   bool replayCommand() const override { return false; }
+  bool isBusy()        const override { return _pendingAngle || _sensePending; }
 
 private:
   void _actuate(int openAngle, int holdMs);


### PR DESCRIPTION
## Summary

- Subscribes to `fishhub/<device_id>/firmware` (retained) in the MQTT client, alongside existing `commands`, `peripherals`, `config`, `triggers`
- `onFirmwareManifest()` semver-compares the received version against `FIRMWARE_VERSION` and deduplicates by nonce (checked against NVS `fw_nonce`); ignores messages that are not newer or already processed
- Safe-point gate in `sensorTick()`: OTA is triggered only when `!manager.anyBusy() && eventQueue.empty()`, preventing a flash mid-actuation or with queued trigger events
- Nonce is persisted to NVS **before** flashing so a failed flash cannot re-trigger on the same nonce on next boot
- `publishStatus("updating")` is called before entering `UPDATE_FIRMWARE`; `publishStatus("failed:flash")` on failure; `publishStatus("ok")` on the first MQTT reconnect after a successful update (with rollback guards cleared)
- Removes the `OTA_TEST_URL`/`OTA_TEST_SHA256` compile-flag test hook (replaced by the MQTT manifest path)

New additions:
- `include/semver.h` — `semverGreater(a, b)` for `"X.Y.Z"` strings
- `Peripheral::isBusy()` (default `false`) — `ServoCR` and `ServoPositional` override to return `true` while `_pendingRotation`/`_pendingAngle` is set (uncommitted actuation state)
- `PeripheralManager::anyBusy()` — iterates entries and returns true if any peripheral is busy

## Test plan

- [x] `pio run -e nodemcu-32s` — clean build
- [x] `pio test -e native` — 93/93 passed
- [ ] Hardware: `mosquitto_pub -r -t 'fishhub/<id>/firmware' -m '{"version":"99.0.0","url":"<presigned>","sha256":"<hex>","nonce":"abc123"}'` → device logs "Newer firmware available", flashes, reboots, reports `last_update_result: ok`
- [ ] Same nonce a second time → ignored ("already processed")
- [ ] Older version → ignored ("not newer")
- [ ] Flash with servo mid-actuation → deferred until idle

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)