### PR TITLE
chore: bump default version to 0.1.2

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -1,5 +1,5 @@
 #pragma once
 
 #ifndef FIRMWARE_VERSION
-#define FIRMWARE_VERSION "0.0.0-dev"
+#define FIRMWARE_VERSION "0.1.2"
 #endif


### PR DESCRIPTION
Bumps the fallback `FIRMWARE_VERSION` in `version.h` to `0.1.2`. The CI workflow overrides this with the git tag at build time, so this also serves as a no-op OTA test trigger — merging and tagging `v0.1.2` will exercise the full auto-update flow end to end.

## Test plan
- [ ] Merge and push tag `v0.1.2`
- [ ] CI builds firmware and uploads to S3
- [ ] Server poller picks up `0.1.2` as `latest_version`
- [ ] Web shows "Update available: 0.1.2" for the device
- [ ] Confirm update from UI → device receives manifest, flashes, reboots
- [ ] Device reports `firmware_version: 0.1.2`, `last_update_result: ok`
- [ ] Web shows "Up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)