### PR TITLE
fix: self-hosted Railway MQTT broker — remove TLS assumption

### DIFF
--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Build firmware
-        run: PLATFORMIO_BUILD_FLAGS="-D MQTT_TLS -D FIRMWARE_VERSION='\"${VERSION}\"' -D SERVER_URL='\"${{ vars.SERVER_URL }}\"'" pio run -e nodemcu-32s
+        run: PLATFORMIO_BUILD_FLAGS="-D FIRMWARE_VERSION='\"${VERSION}\"' -D SERVER_URL='\"${{ vars.SERVER_URL }}\"' -D MQTT_PORT=${{ vars.MQTT_PORT || 1883 }}" pio run -e nodemcu-32s
 
       - name: Compute sha256 and size
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,9 +136,11 @@ sensorTick()                 (every loop while in NORMAL_OPERATION)
 
 ## MQTT topic topology
 
-All topics are namespaced `fishhub/<device_id>/…`. The connection is TLS
-(ISRG Root X1 CA, port 8883 on HiveMQ Cloud) when `MQTT_TLS` is defined;
-plain TCP otherwise (e.g. a self-hosted broker behind a TCP proxy).
+All topics are namespaced `fishhub/<device_id>/…`. The connection uses TLS
+(ISRG Root X1 CA) when `MQTT_TLS` is defined at build time; plain TCP otherwise.
+The current production setup is a self-hosted broker on Railway accessed via a
+Railway TCP proxy (plain TCP, no `MQTT_TLS`). The broker port is compile-time
+(`MQTT_PORT`; set via build flags in CI or `config.h` locally).
 
 **Subscribes (inbound):**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,9 +39,9 @@ If activation fails (wrong code, Wi-Fi unreachable, server error, or 60 s poll t
 | `wifi_pass` | Wi-Fi password |
 | `device_id` | UUID assigned by the server |
 | `device_jwt` | Bearer token for authenticating to the server |
-| `mqtt_username` | HiveMQ Cloud username |
-| `mqtt_password` | HiveMQ Cloud password |
-| `mqtt_host` | HiveMQ Cloud hostname |
+| `mqtt_username` | MQTT broker username |
+| `mqtt_password` | MQTT broker password |
+| `mqtt_host` | MQTT broker hostname |
 | `provisioned` | Atomicity flag — written `"1"` last; absent means provisioning was interrupted |
 
 The `provisioned` flag makes writes atomic: if power is lost between writing individual keys and setting the flag, `isProvisioned()` returns `false` and the device re-enters AP mode on the next boot so the user can try again.
@@ -76,8 +76,7 @@ Then fill in the defines:
 
 #define SERVER_URL   "http://192.168.x.x:8080"
 
-#define MQTT_HOST    "your-cluster.hivemq.cloud"
-#define MQTT_PORT    8883
+#define MQTT_PORT    1883   // or your broker's port (e.g. Railway TCP proxy port)
 #define DEVICE_ID    ""   // leave empty — populated by provisioning
 ```
 
@@ -86,8 +85,8 @@ Then fill in the defines:
 | `WIFI_SSID` | SSID of the Wi-Fi network the ESP32 will join (NVS takes precedence on provisioned devices) |
 | `WIFI_PASSWORD` | Wi-Fi password (NVS takes precedence) |
 | `SERVER_URL` | Base URL of the FishHub backend — compiled in at build time, never stored in NVS. Use the local IP; `localhost` won't resolve on device. `"/readings"` and `"/devices/..."` paths are appended by the firmware. |
-| `MQTT_HOST` | HiveMQ Cloud broker hostname (NVS takes precedence on provisioned devices) |
-| `MQTT_PORT` | HiveMQ Cloud broker port (default `8883`) |
+| `MQTT_HOST` | MQTT broker hostname (NVS takes precedence on provisioned devices) |
+| `MQTT_PORT` | MQTT broker port — compile-time only; defaults to `8883` with `MQTT_TLS`, `1883` without |
 | `DEVICE_ID` | Leave empty — populated automatically by provisioning |
 
 `SERVER_URL` is always read from `config.h` at compile time. `WIFI_SSID`, `WIFI_PASSWORD`, and `MQTT_HOST` are fallbacks used only when the corresponding NVS keys are empty.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ESP32 Arduino firmware for FishHub aquarium monitoring. On first boot (or after a
 factory reset) the device starts a captive-portal Wi-Fi AP for provisioning. Once
-provisioned, it holds a persistent TLS MQTT connection: it **publishes sensor
+provisioned, it holds a persistent MQTT connection: it **publishes sensor
 readings and trigger events** over MQTT and **reacts to inbound MQTT messages**
 that provision peripherals, push automation triggers, set device config, and send
 commands. The device is online full-time — there is no deep-sleep / wake-and-POST
@@ -46,9 +46,9 @@ pio device monitor
 | Framework | Arduino |
 | Temperature sensor | DS18B20 via OneWire / DallasTemperature |
 | JSON serialization | ArduinoJson v7 |
-| Data transport | MQTT (PubSubClient) over TLS — readings + trigger events published, config/commands/peripherals/triggers received |
+| Data transport | MQTT (PubSubClient) — readings + trigger events published, config/commands/peripherals/triggers received |
 | HTTP client | ESP32 built-in HTTPClient — provisioning/activation only |
-| MQTT broker | HiveMQ Cloud (TLS, port 8883) in production; plain TCP supported for self-hosted brokers |
+| MQTT broker | Self-hosted broker on Railway (plain TCP via Railway TCP proxy); TLS supported via `MQTT_TLS` build flag |
 | Wire format | SenML JSON (RFC 8428) |
 | Auth | Device JWT stored in NVS (provisioned via captive portal) |
 | MQTT auth | Username / password stored in NVS (issued by the server at activation) |

--- a/docs/peripherals.md
+++ b/docs/peripherals.md
@@ -208,9 +208,9 @@ Time-window–based on/off logic used by `RelayActuator`.
 
 ## `FishHubMqttClient` (`src/mqtt_client.h/.cpp`)
 
-Manages the TLS MQTT connection and routes inbound commands to `PeripheralManager`.
+Manages the MQTT connection and routes inbound commands to `PeripheralManager`.
 
-- Connects to HiveMQ Cloud on port 8883 using the ISRG Root X1 CA.
+- Connects to the broker using plain TCP (or TLS when `MQTT_TLS` is defined).
 - Subscribes to `fishhub/<device_id>/commands/#`.
 - On each message, extracts the peripheral name from the last topic segment and calls `PeripheralManager::dispatchCommand()`.
 - For peripherals with `replayCommand() == false`, persists the last processed command ID in NVS under `cmd_<name>` and skips duplicates.

--- a/include/version.h
+++ b/include/version.h
@@ -1,5 +1,5 @@
 #pragma once
 
 #ifndef FIRMWARE_VERSION
-#define FIRMWARE_VERSION "0.0.0-dev"
+#define FIRMWARE_VERSION "0.1.2"
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,6 @@ monitor_speed = 115200
 board_build.partitions = default.csv
 ; FIRMWARE_VERSION is injected by CI: -D FIRMWARE_VERSION='"X.Y.Z"'
 ; Local builds fall back to the value in include/version.h.
-build_flags = -D MQTT_TLS
 lib_deps =
   paulstoffregen/OneWire @ ^2.3.8
   milesburton/DallasTemperature @ ^3.11.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,8 @@ framework     = arduino
 monitor_speed = 115200
 board_build.partitions = default.csv
 ; FIRMWARE_VERSION is injected by CI: -D FIRMWARE_VERSION='"X.Y.Z"'
-; Local builds fall back to "0.0.0-dev" (defined in include/version.h).
+; Local builds fall back to the value in include/version.h.
+build_flags = -D MQTT_TLS
 lib_deps =
   paulstoffregen/OneWire @ ^2.3.8
   milesburton/DallasTemperature @ ^3.11.0


### PR DESCRIPTION
The CI workflow and `platformio.ini` assumed HiveMQ Cloud (TLS, port 8883), but the broker is now self-hosted on Railway via a plain TCP proxy.

## Changes
- `platformio.ini`: remove `-D MQTT_TLS` from build flags
- CI workflow: replace `-D MQTT_TLS` with `MQTT_PORT` from a GitHub Actions variable (`vars.MQTT_PORT`), so the OTA binary uses the correct port
- Docs: replace all HiveMQ Cloud references with self-hosted Railway broker

## Action required
Add `MQTT_PORT = 32931` as a repository variable in GitHub Actions (Settings → Secrets and variables → Actions → Variables) before the next release tag so CI builds the firmware with the correct port.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)