### PR TITLE
fix: prefer non-empty MQTT_HOST from config.h over NVS

### DIFF
--- a/src/mqtt_client.cpp
+++ b/src/mqtt_client.cpp
@@ -60,7 +60,11 @@ void FishHubMqttClient::begin(PeripheralManager &manager, TriggerEventQueue &eve
   _mqttPassword = nvsStore.get("mqtt_password");
 
   _mqttHost = nvsStore.get("mqtt_host");
-  if (_mqttHost.isEmpty())
+  // A non-empty MQTT_HOST in config.h is an explicit override — takes
+  // precedence over NVS so local dev builds can force a specific broker.
+  if (MQTT_HOST[0] != '\0')
+    _mqttHost = MQTT_HOST;
+  else if (_mqttHost.isEmpty())
     _mqttHost = MQTT_HOST;
   _mqttPort = MQTT_PORT;
 
@@ -72,6 +76,13 @@ void FishHubMqttClient::begin(PeripheralManager &manager, TriggerEventQueue &eve
 #endif
   _client.setBufferSize(1024);
   _client.setKeepAlive(30);
+  Serial.printf("MQTT: broker %s:%d (%s)\n", _mqttHost.c_str(), _mqttPort,
+#ifdef MQTT_TLS
+                "TLS"
+#else
+                "plain TCP"
+#endif
+  );
   _client.setServer(_mqttHost.c_str(), _mqttPort);
   _client.setCallback([this](char *topic, byte *payload, unsigned int len)
                       { onMessage(topic, payload, len); });


### PR DESCRIPTION
When `MQTT_HOST` is explicitly set in `config.h` (non-empty), it now takes precedence over the NVS value. This lets local dev builds force a specific broker without reprovisioning — useful when NVS has a stale or incorrect host (e.g. an internal Railway domain instead of the TCP proxy).

Also adds a broker debug print at startup:
```
MQTT: broker turntable.proxy.rlwy.net:32931 (plain TCP)
```

Devices without a `config.h` or with `MQTT_HOST ""` (the default) are unaffected — NVS still wins for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)